### PR TITLE
Update GQL queries to handle space profile movement under space about

### DIFF
--- a/graphql/fragments/space-details.graphql
+++ b/graphql/fragments/space-details.graphql
@@ -1,22 +1,13 @@
 fragment SpaceDetails on Space {
   id
   nameID
-  profile {
-    displayName
-    visuals {
-      name
-      id
-    }
-    tagset {
-      tags
-      id
-      name
+  about {
+    id
+    profile {
+      ...ProfileFields
     }
   }
   community {
-    id
-  }
-  context {
     id
   }
 }

--- a/graphql/fragments/space-ingest.graphql
+++ b/graphql/fragments/space-ingest.graphql
@@ -2,13 +2,13 @@ fragment SpaceIngest on Space {
   id
   nameID
   type
-  profile {
-    ...ProfileFields
-  }
-  context {
-    vision
-    impact
+  about {
+    id
+    profile {
+      ...ProfileFields
+    }
     who
+    why
   }
 
   collaboration {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@alkemio/ingest-alkemio-data",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@alkemio/ingest-alkemio-data",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "EUPL-1.2",
       "dependencies": {
         "@alkemio/client-lib": "^0.31.0",
@@ -26,6 +26,7 @@
         "langchain": "^0.2.2",
         "langsmith": "^0.1.66",
         "mammoth": "^1.7.2",
+        "node-html-parser": "^7.0.1",
         "officeparser": "^4.1.1",
         "pdf-parse": "^1.1.1",
         "winston": "^3.13.0",
@@ -4765,6 +4766,11 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
       "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA=="
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -5493,6 +5499,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
@@ -5802,6 +5834,57 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dot-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
@@ -5920,6 +6003,17 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -7111,6 +7205,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
       }
     },
     "node_modules/header-case": {
@@ -8646,6 +8748,15 @@
         }
       }
     },
+    "node_modules/node-html-parser": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-7.0.1.tgz",
+      "integrity": "sha512-KGtmPY2kS0thCWGK0VuPyOS+pBKhhe8gXztzA2ilAOhbUbxa9homF1bOyKvhGzMLXUoRds9IOmr/v5lr/lqNmA==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -8723,6 +8834,17 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@alkemio/ingest-alkemio-data",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "",
   "author": "Alkemio Foundation",
   "private": true,
@@ -61,6 +61,7 @@
     "langchain": "^0.2.2",
     "langsmith": "^0.1.66",
     "mammoth": "^1.7.2",
+    "node-html-parser": "^7.0.1",
     "officeparser": "^4.1.1",
     "pdf-parse": "^1.1.1",
     "winston": "^3.13.0",

--- a/src/callout.handlers/base.ts
+++ b/src/callout.handlers/base.ts
@@ -1,7 +1,7 @@
 import { Logger } from 'winston';
 import { Callout } from '../generated/graphql';
 import { Document } from 'langchain/document';
-import generateDocument from '../generate.document';
+import { generateDocument } from '../generate.document';
 
 export const baseHandler = async (
   callout: Partial<Callout>,

--- a/src/data.readers/knowledge.base.ts
+++ b/src/data.readers/knowledge.base.ts
@@ -1,9 +1,9 @@
-import generateDocument from '../generate.document';
 import { Document } from 'langchain/document';
 import { IngestBodyOfKnowledge } from '../event.bus/events/ingest.body.of.knowledge';
 import { AlkemioCliClient } from '../graphql.client/AlkemioCliClient';
 import { processCallouts } from '../process.callouts';
 import { Callout } from '../generated/graphql';
+import { generateDocument } from '../generate.document';
 
 export const embedKnowledgeBase = async (
   event: IngestBodyOfKnowledge,

--- a/src/data.readers/process.space.tree.ts
+++ b/src/data.readers/process.space.tree.ts
@@ -2,7 +2,7 @@ import { Document } from 'langchain/document';
 
 import { Space } from '../generated/graphql';
 
-import generateDocument from '../generate.document';
+import { generateDocument } from '../generate.document';
 import { AlkemioCliClient } from '../graphql.client/AlkemioCliClient';
 import { processCallouts } from '../process.callouts';
 

--- a/src/data.readers/types.d.ts
+++ b/src/data.readers/types.d.ts
@@ -1,6 +1,11 @@
+export declare type Profile = {
+  displayName: string;
+  url: string;
+};
 export declare type BodyOfKnowledgeReadResult = {
+  profile?: Profile;
+  about?: { profile: Profile };
   id: string;
-  profile: { displayName: string; url: string };
 };
 
 export declare type ReadResult = {

--- a/src/embed.documents.ts
+++ b/src/embed.documents.ts
@@ -103,9 +103,13 @@ export const embedDocuments = async (
 
   metadatas.push({
     documentId: bokID,
-    source: bodyOfKnowledge.profile.url,
+    source:
+      bodyOfKnowledge.profile?.url || bodyOfKnowledge.about?.profile.url || '',
     type: 'bodyOfKnowledgeSummary',
-    title: bodyOfKnowledge.profile?.displayName,
+    title:
+      bodyOfKnowledge.profile?.displayName ||
+      bodyOfKnowledge.about?.profile.displayName ||
+      '',
   });
 
   logger.info('Connecting to Chroma...');

--- a/src/generate.document.ts
+++ b/src/generate.document.ts
@@ -37,8 +37,13 @@ export const generateDocument = (docLike: any): GeneratedDocument => {
   if (tagset?.tags.length)
     pageContent = `${pageContent}\nTags: ${tagset?.tags.join(', ')}`;
   if (description) {
-    const descriptionRoot = parse(description);
-    pageContent = `${pageContent}\nDescription: ${descriptionRoot.structuredText}`;
+    try {
+      const descriptionRoot = parse(description);
+      pageContent = `${pageContent}\nDescription: ${descriptionRoot.structuredText}`;
+    } catch (error) {
+      console.error('Error parsing HTML description:', error);
+      pageContent = `${pageContent}\nDescription: ${description}`; // Fallback to raw description
+    }
   }
   if (why) pageContent = `${pageContent}\nWhy: ${why}`;
   if (who) pageContent = `${pageContent}\nWho: ${who}`;
@@ -66,7 +71,6 @@ export const generateDocument = (docLike: any): GeneratedDocument => {
     pageContent = `${pageContent}\nReferences:\n${processedRefs}`;
 
   pageContent = `${pageContent}\nURL: ${source}`;
-  console.log(pageContent);
   return {
     documentId,
     source,

--- a/src/generate.document.ts
+++ b/src/generate.document.ts
@@ -44,7 +44,7 @@ export const generateDocument = (docLike: any): GeneratedDocument => {
   if (who) pageContent = `${pageContent}\nWho: ${who}`;
 
   let processedVisuals = '';
-  visuals.forEach((visual: Visual) => {
+  (visuals || []).forEach((visual: Visual) => {
     if (visual.uri) {
       processedVisuals += `\t${visual.name}: ${visual.uri}`;
     }
@@ -56,7 +56,7 @@ export const generateDocument = (docLike: any): GeneratedDocument => {
   if (postalCode || city || country)
     pageContent = `${pageContent}\nLocation: ${postalCode} ${city} ${country}`;
 
-  const processedRefs = references
+  const processedRefs = (references || [])
     .map(
       ({ description, name, uri }: Reference) =>
         `\tReference name: ${name}\n\tReference description: ${description}\n\tUri: ${uri}\n`

--- a/src/generate.document.ts
+++ b/src/generate.document.ts
@@ -1,5 +1,6 @@
 import { Reference, Visual } from './generated/graphql';
 import { DocumentType, mapType } from './document.type';
+import { parse } from 'node-html-parser';
 
 interface GeneratedDocument {
   documentId: string;
@@ -10,53 +11,62 @@ interface GeneratedDocument {
 }
 
 //TODO type this pls
-export default (docLike: any): GeneratedDocument => {
-  const {
-    id: documentId,
-    type,
-    profile: {
-      references,
-      tagset,
-      url: source,
-      description,
-      tagline,
-      displayName,
-      location,
-      visuals,
-      type: profileType,
-    },
-    context,
-  } = docLike;
+export const generateDocument = (docLike: any): GeneratedDocument => {
+  const { id: documentId, type } = docLike;
 
-  const { vision, impact, who } = context || {};
+  const {
+    references,
+    tagset,
+    url: source,
+    description,
+    tagline,
+    displayName,
+    location,
+    visuals,
+    type: profileType,
+    who,
+    why,
+  } = docLike.profile || docLike.about.profile || {};
+
+  // const { vision, impact, who } = context || {};
+
   const { city, country, postalCode } = location || {};
 
   let pageContent = `Name: ${displayName}`;
   if (tagline) pageContent = `${pageContent}\nTagline: ${tagline}`;
   if (tagset?.tags.length)
     pageContent = `${pageContent}\nTags: ${tagset?.tags.join(', ')}`;
-  if (description) pageContent = `${pageContent}\nDescription: ${description}`;
-  if (impact) pageContent = `${pageContent}\nImpact: ${impact}`;
-  if (vision) pageContent = `${pageContent}\nVision: ${vision}`;
+  if (description) {
+    const descriptionRoot = parse(description);
+    pageContent = `${pageContent}\nDescription: ${descriptionRoot.structuredText}`;
+  }
+  if (why) pageContent = `${pageContent}\nWhy: ${why}`;
   if (who) pageContent = `${pageContent}\nWho: ${who}`;
 
-  const processedVisuals = visuals
-    .map((visual: Visual) => `\t${visual.name}: ${visual.uri}`)
-    .join('\n');
+  let processedVisuals = '';
+  visuals.forEach((visual: Visual) => {
+    if (visual.uri) {
+      processedVisuals += `\t${visual.name}: ${visual.uri}`;
+    }
+  });
+
   if (processedVisuals)
-    pageContent = `${pageContent}\nVisuals: ${processedVisuals}`;
+    pageContent = `${pageContent}\nVisuals:\n${processedVisuals}`;
 
   if (postalCode || city || country)
     pageContent = `${pageContent}\nLocation: ${postalCode} ${city} ${country}`;
 
-  const processedRefs = references.map(
-    ({ description, name, uri }: Reference) =>
-      `\tReference name: ${name}\n\tReference description: ${description}\n\tUri: ${uri}\n`
-  );
+  const processedRefs = references
+    .map(
+      ({ description, name, uri }: Reference) =>
+        `\tReference name: ${name}\n\tReference description: ${description}\n\tUri: ${uri}\n`
+    )
+    .join('\n');
   if (processedRefs)
     pageContent = `${pageContent}\nReferences:\n${processedRefs}`;
 
   pageContent = `${pageContent}\nURL: ${source}`;
+  console.log(pageContent);
   return {
     documentId,
     source,

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -39,8 +39,6 @@ export type Scalars = {
   MessageID: any;
   NameID: string;
   UUID: string;
-  UUID_NAMEID: string;
-  UUID_NAMEID_EMAIL: string;
   Upload: import('graphql-upload').FileUpload;
   WhiteboardContent: any;
 };
@@ -437,7 +435,7 @@ export type ActivityLogEntryMemberJoined = ActivityLogEntry & {
   /** The Contributor that joined the Community. */
   contributor: Contributor;
   /** The type of the Contributor that joined the Community. */
-  contributorType: CommunityContributorType;
+  contributorType: RoleSetContributorType;
   /** The timestamp for the Activity. */
   createdDate: Scalars['DateTime'];
   /** The text details for this Activity. */
@@ -518,40 +516,6 @@ export type ActivityLogInput = {
   types?: InputMaybe<Array<ActivityEventType>>;
 };
 
-export type Actor = {
-  /** The authorization rules for the entity */
-  authorization?: Maybe<Authorization>;
-  /** The date at which the entity was created. */
-  createdDate?: Maybe<Scalars['DateTime']>;
-  /** A description of this actor */
-  description?: Maybe<Scalars['String']>;
-  /** The ID of the entity */
-  id: Scalars['UUID'];
-  /** The change / effort required of this actor */
-  impact?: Maybe<Scalars['String']>;
-  name: Scalars['String'];
-  /** The date at which the entity was last updated. */
-  updatedDate?: Maybe<Scalars['DateTime']>;
-  /** A value derived by this actor */
-  value?: Maybe<Scalars['String']>;
-};
-
-export type ActorGroup = {
-  /** The set of actors in this actor group */
-  actors?: Maybe<Array<Actor>>;
-  /** The authorization rules for the entity */
-  authorization?: Maybe<Authorization>;
-  /** The date at which the entity was created. */
-  createdDate?: Maybe<Scalars['DateTime']>;
-  /** A description of this group of actors */
-  description?: Maybe<Scalars['String']>;
-  /** The ID of the entity */
-  id: Scalars['UUID'];
-  name: Scalars['String'];
-  /** The date at which the entity was last updated. */
-  updatedDate?: Maybe<Scalars['DateTime']>;
-};
-
 export type Agent = {
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
@@ -608,6 +572,8 @@ export type AiPersona = {
   dataAccessMode: AiPersonaDataAccessMode;
   /** The description for this AI Persona. */
   description?: Maybe<Scalars['Markdown']>;
+  /** The engine powering the AiPersona. */
+  engine: AiPersonaEngine;
   /** The ID of the entity */
   id: Scalars['UUID'];
   /** The type of interactions that are supported by this AI Persona when used. */
@@ -621,6 +587,7 @@ export enum AiPersonaBodyOfKnowledgeType {
   AlkemioSpace = 'ALKEMIO_SPACE',
   None = 'NONE',
   Other = 'OTHER',
+  Website = 'WEBSITE',
 }
 
 export enum AiPersonaDataAccessMode {
@@ -662,10 +629,6 @@ export type AiPersonaService = {
   prompt: Array<Scalars['String']>;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']>;
-};
-
-export type AiPersonaServiceIngestInput = {
-  aiPersonaServiceID: Scalars['UUID'];
 };
 
 export type AiServer = {
@@ -737,32 +700,26 @@ export type AssignLicensePlanToSpace = {
   spaceID: Scalars['UUID'];
 };
 
-export type AssignOrganizationRoleToUserInput = {
-  organizationID: Scalars['UUID'];
-  role: OrganizationRole;
-  userID: Scalars['UUID'];
-};
-
-export type AssignPlatformRoleToUserInput = {
-  role: PlatformRole;
-  userID: Scalars['UUID'];
+export type AssignPlatformRoleInput = {
+  contributorID: Scalars['UUID'];
+  role: RoleName;
 };
 
 export type AssignRoleOnRoleSetToOrganizationInput = {
   contributorID: Scalars['UUID'];
-  role: CommunityRoleType;
+  role: RoleName;
   roleSetID: Scalars['UUID'];
 };
 
 export type AssignRoleOnRoleSetToUserInput = {
   contributorID: Scalars['UUID'];
-  role: CommunityRoleType;
+  role: RoleName;
   roleSetID: Scalars['UUID'];
 };
 
 export type AssignRoleOnRoleSetToVirtualContributorInput = {
   contributorID: Scalars['UUID'];
-  role: CommunityRoleType;
+  role: RoleName;
   roleSetID: Scalars['UUID'];
 };
 
@@ -820,6 +777,7 @@ export type Authorization = {
 };
 
 export enum AuthorizationCredential {
+  AccountAdmin = 'ACCOUNT_ADMIN',
   BetaTester = 'BETA_TESTER',
   GlobalAdmin = 'GLOBAL_ADMIN',
   GlobalAnonymous = 'GLOBAL_ANONYMOUS',
@@ -834,6 +792,7 @@ export enum AuthorizationCredential {
   SpaceAdmin = 'SPACE_ADMIN',
   SpaceLead = 'SPACE_LEAD',
   SpaceMember = 'SPACE_MEMBER',
+  SpaceMemberInvitee = 'SPACE_MEMBER_INVITEE',
   SpaceSubspaceAdmin = 'SPACE_SUBSPACE_ADMIN',
   UserGroupMember = 'USER_GROUP_MEMBER',
   UserSelfManagement = 'USER_SELF_MANAGEMENT',
@@ -861,8 +820,6 @@ export type AuthorizationPolicyRuleVerifiedCredential = {
 
 export enum AuthorizationPolicyType {
   Account = 'ACCOUNT',
-  Actor = 'ACTOR',
-  ActorGroup = 'ACTOR_GROUP',
   Agent = 'AGENT',
   AiPersona = 'AI_PERSONA',
   AiPersonaService = 'AI_PERSONA_SERVICE',
@@ -878,10 +835,8 @@ export enum AuthorizationPolicyType {
   Communication = 'COMMUNICATION',
   Community = 'COMMUNITY',
   CommunityGuidelines = 'COMMUNITY_GUIDELINES',
-  Context = 'CONTEXT',
   Discussion = 'DISCUSSION',
   Document = 'DOCUMENT',
-  EcosystemModel = 'ECOSYSTEM_MODEL',
   Forum = 'FORUM',
   InnovationFlow = 'INNOVATION_FLOW',
   InnovationHub = 'INNOVATION_HUB',
@@ -905,6 +860,7 @@ export enum AuthorizationPolicyType {
   RoleSet = 'ROLE_SET',
   Room = 'ROOM',
   Space = 'SPACE',
+  SpaceAbout = 'SPACE_ABOUT',
   StorageAggregator = 'STORAGE_AGGREGATOR',
   StorageBucket = 'STORAGE_BUCKET',
   Tagset = 'TAGSET',
@@ -923,13 +879,9 @@ export enum AuthorizationPolicyType {
 
 export enum AuthorizationPrivilege {
   AccessInteractiveGuidance = 'ACCESS_INTERACTIVE_GUIDANCE',
+  AccountLicenseManage = 'ACCOUNT_LICENSE_MANAGE',
   AuthorizationReset = 'AUTHORIZATION_RESET',
-  CommunityAddMember = 'COMMUNITY_ADD_MEMBER',
-  CommunityAddMemberVcFromAccount = 'COMMUNITY_ADD_MEMBER_VC_FROM_ACCOUNT',
-  CommunityApply = 'COMMUNITY_APPLY',
-  CommunityInvite = 'COMMUNITY_INVITE',
-  CommunityInviteAccept = 'COMMUNITY_INVITE_ACCEPT',
-  CommunityJoin = 'COMMUNITY_JOIN',
+  CommunityAssignVcFromAccount = 'COMMUNITY_ASSIGN_VC_FROM_ACCOUNT',
   Contribute = 'CONTRIBUTE',
   Create = 'CREATE',
   CreateCallout = 'CREATE_CALLOUT',
@@ -954,12 +906,19 @@ export enum AuthorizationPrivilege {
   MoveContribution = 'MOVE_CONTRIBUTION',
   MovePost = 'MOVE_POST',
   PlatformAdmin = 'PLATFORM_ADMIN',
+  PlatformSettingsAdmin = 'PLATFORM_SETTINGS_ADMIN',
   Read = 'READ',
   ReadAbout = 'READ_ABOUT',
   ReadUsers = 'READ_USERS',
   ReadUserPii = 'READ_USER_PII',
   ReadUserSettings = 'READ_USER_SETTINGS',
-  TransferResource = 'TRANSFER_RESOURCE',
+  RolesetEntryRoleApply = 'ROLESET_ENTRY_ROLE_APPLY',
+  RolesetEntryRoleAssign = 'ROLESET_ENTRY_ROLE_ASSIGN',
+  RolesetEntryRoleInvite = 'ROLESET_ENTRY_ROLE_INVITE',
+  RolesetEntryRoleInviteAccept = 'ROLESET_ENTRY_ROLE_INVITE_ACCEPT',
+  RolesetEntryRoleJoin = 'ROLESET_ENTRY_ROLE_JOIN',
+  TransferResourceAccept = 'TRANSFER_RESOURCE_ACCEPT',
+  TransferResourceOffer = 'TRANSFER_RESOURCE_OFFER',
   Update = 'UPDATE',
   UpdateCalloutPublisher = 'UPDATE_CALLOUT_PUBLISHER',
   UpdateContent = 'UPDATE_CONTENT',
@@ -982,7 +941,7 @@ export type Calendar = {
 };
 
 export type CalendarEventArgs = {
-  ID: Scalars['UUID_NAMEID'];
+  ID: Scalars['UUID'];
 };
 
 export type CalendarEvent = {
@@ -1069,8 +1028,7 @@ export type Callout = {
 };
 
 export type CalloutContributionsArgs = {
-  IDs?: InputMaybe<Array<Scalars['UUID_NAMEID']>>;
-  filter?: InputMaybe<CalloutContributionFilterArgs>;
+  IDs?: InputMaybe<Array<Scalars['UUID']>>;
   limit?: InputMaybe<Scalars['Float']>;
   shuffle?: InputMaybe<Scalars['Boolean']>;
 };
@@ -1107,15 +1065,6 @@ export type CalloutContributionDefaults = {
   updatedDate?: Maybe<Scalars['DateTime']>;
   /** The default whiteboard content for whiteboard responses. */
   whiteboardContent?: Maybe<Scalars['WhiteboardContent']>;
-};
-
-export type CalloutContributionFilterArgs = {
-  /** Include Contributions with Link ids of contributions to include. */
-  linkIDs?: InputMaybe<Array<Scalars['UUID']>>;
-  /** Include Contributions with Post ids/nameIds. */
-  postIDs?: InputMaybe<Array<Scalars['UUID_NAMEID']>>;
-  /** Include Contributions with Whiteboard ids/nameIds. */
-  whiteboardIDs?: InputMaybe<Array<Scalars['UUID_NAMEID']>>;
 };
 
 export type CalloutContributionPolicy = {
@@ -1211,19 +1160,25 @@ export type CalloutsSet = {
   /** The tagset templates on this CalloutsSet. */
   tagsetTemplates?: Maybe<Array<TagsetTemplate>>;
   /** The set of CalloutGroups in use in this CalloutsSet. */
-  type: Array<CalloutGroup>;
+  type: CalloutsSetType;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']>;
 };
 
 export type CalloutsSetCalloutsArgs = {
-  IDs?: InputMaybe<Array<Scalars['UUID_NAMEID']>>;
+  IDs?: InputMaybe<Array<Scalars['UUID']>>;
   groups?: InputMaybe<Array<Scalars['String']>>;
   limit?: InputMaybe<Scalars['Float']>;
   shuffle?: InputMaybe<Scalars['Boolean']>;
   sortByActivity?: InputMaybe<Scalars['Boolean']>;
   tagsets?: InputMaybe<Array<TagsetArgs>>;
+  types?: InputMaybe<Array<CalloutType>>;
 };
+
+export enum CalloutsSetType {
+  Collaboration = 'COLLABORATION',
+  KnowledgeBase = 'KNOWLEDGE_BASE',
+}
 
 export type ChatGuidanceAnswerRelevanceInput = {
   /** The answer id. */
@@ -1414,12 +1369,6 @@ export type CommunityApplicationResult = {
   spacePendingMembershipInfo: SpacePendingMembershipInfo;
 };
 
-export enum CommunityContributorType {
-  Organization = 'ORGANIZATION',
-  User = 'USER',
-  Virtual = 'VIRTUAL',
-}
-
 export type CommunityGuidelines = {
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
@@ -1439,7 +1388,7 @@ export type CommunityInvitationForRoleResult = {
   /** ID for Contrbutor that is being invited to a community */
   contributorID: Scalars['UUID'];
   /** The Type of the Contrbutor that is being invited to a community */
-  contributorType: CommunityContributorType;
+  contributorType: RoleSetContributorType;
   /** ID for the user that created the invitation. */
   createdBy: Scalars['UUID'];
   /** Date of creation */
@@ -1491,16 +1440,6 @@ export enum CommunityMembershipStatus {
   NotMember = 'NOT_MEMBER',
 }
 
-export enum CommunityRoleImplicit {
-  SubspaceAdmin = 'SUBSPACE_ADMIN',
-}
-
-export enum CommunityRoleType {
-  Admin = 'ADMIN',
-  Lead = 'LEAD',
-  Member = 'MEMBER',
-}
-
 export type Config = {
   /** Elastic APM (RUM & performance monitoring) related configuration. */
   apm: Apm;
@@ -1529,23 +1468,6 @@ export enum ContentUpdatePolicy {
   Contributors = 'CONTRIBUTORS',
   Owner = 'OWNER',
 }
-
-export type Context = {
-  /** The authorization rules for the entity */
-  authorization?: Maybe<Authorization>;
-  /** The date at which the entity was created. */
-  createdDate?: Maybe<Scalars['DateTime']>;
-  /** The ID of the entity */
-  id: Scalars['UUID'];
-  /** What is the potential impact? */
-  impact?: Maybe<Scalars['Markdown']>;
-  /** The date at which the entity was last updated. */
-  updatedDate?: Maybe<Scalars['DateTime']>;
-  /** The goal that is being pursued */
-  vision?: Maybe<Scalars['Markdown']>;
-  /** Who should get involved in this challenge */
-  who?: Maybe<Scalars['Markdown']>;
-};
 
 export type Contributor = {
   /** The Agent for the Contributor. */
@@ -1592,28 +1514,19 @@ export type ContributorRolesInvitationsArgs = {
   states?: InputMaybe<Array<Scalars['String']>>;
 };
 
+export type ConversionVcSpaceToVcKnowledgeBaseInput = {
+  /** The Virtual Contributor to be converted. */
+  virtualContributorID: Scalars['UUID'];
+};
+
 export type ConvertSubspaceToSpaceInput = {
   /** The subspace to be promoted to be a new Space. Note: the original Subspace will no longer exist after the conversion.  */
-  subspaceID: Scalars['UUID_NAMEID'];
+  subspaceID: Scalars['UUID'];
 };
 
 export type ConvertSubsubspaceToSubspaceInput = {
   /** The subsubspace to be promoted. Note: the original Opportunity will no longer exist after the conversion.  */
-  subsubspaceID: Scalars['UUID_NAMEID'];
-};
-
-export type CreateActorGroupInput = {
-  description?: InputMaybe<Scalars['String']>;
-  ecosystemModelID: Scalars['UUID'];
-  name: Scalars['String'];
-};
-
-export type CreateActorInput = {
-  actorGroupID: Scalars['UUID'];
-  description?: InputMaybe<Scalars['String']>;
-  impact?: InputMaybe<Scalars['String']>;
-  name: Scalars['String'];
-  value?: InputMaybe<Scalars['String']>;
+  subsubspaceID: Scalars['UUID'];
 };
 
 export type CreateAiPersonaInput = {
@@ -1793,12 +1706,6 @@ export type CreateCommunityGuidelinesInput = {
   profile: CreateProfileInput;
 };
 
-export type CreateContextInput = {
-  impact?: InputMaybe<Scalars['Markdown']>;
-  vision?: InputMaybe<Scalars['Markdown']>;
-  who?: InputMaybe<Scalars['Markdown']>;
-};
-
 export type CreateContributionOnCalloutInput = {
   calloutID: Scalars['UUID'];
   link?: InputMaybe<CreateLinkInput>;
@@ -1931,14 +1838,6 @@ export type CreateOrganizationInput = {
   website?: InputMaybe<Scalars['String']>;
 };
 
-export type CreatePlatformInvitationForRoleInput = {
-  email: Scalars['String'];
-  firstName?: InputMaybe<Scalars['String']>;
-  lastName?: InputMaybe<Scalars['String']>;
-  platformRole: PlatformRole;
-  welcomeMessage?: InputMaybe<Scalars['String']>;
-};
-
 export type CreatePostInput = {
   /** A readable identifier, unique within the containing scope. */
   nameID?: InputMaybe<Scalars['NameID']>;
@@ -1954,6 +1853,7 @@ export type CreateProfileData = {
   referencesData?: Maybe<Array<CreateReferenceData>>;
   /** A memorable short description for this entity. */
   tagline?: Maybe<Scalars['String']>;
+  tags?: Maybe<Array<Scalars['String']>>;
   tagsets?: Maybe<Array<CreateTagsetData>>;
   /** The visuals URLs */
   visuals?: Maybe<Array<CreateVisualOnProfileData>>;
@@ -1967,6 +1867,7 @@ export type CreateProfileInput = {
   referencesData?: InputMaybe<Array<CreateReferenceInput>>;
   /** A memorable short description for this entity. */
   tagline?: InputMaybe<Scalars['String']>;
+  tags?: InputMaybe<Array<Scalars['String']>>;
   tagsets?: InputMaybe<Array<CreateTagsetInput>>;
   /** The visuals URLs */
   visuals?: InputMaybe<Array<CreateVisualOnProfileInput>>;
@@ -1991,28 +1892,31 @@ export type CreateReferenceOnProfileInput = {
   uri?: InputMaybe<Scalars['String']>;
 };
 
+export type CreateSpaceAboutInput = {
+  profileData: CreateProfileInput;
+  when?: InputMaybe<Scalars['Markdown']>;
+  who?: InputMaybe<Scalars['Markdown']>;
+  why?: InputMaybe<Scalars['Markdown']>;
+};
+
 export type CreateSpaceOnAccountInput = {
+  about: CreateSpaceAboutInput;
   /** The Account where the Space is to be created. */
   accountID: Scalars['UUID'];
   collaborationData: CreateCollaborationOnSpaceInput;
-  context?: InputMaybe<CreateContextInput>;
   /** The license plan the user wishes to use when creating the space. */
   licensePlanID?: InputMaybe<Scalars['UUID']>;
   /** A readable identifier, unique within the containing scope. */
   nameID?: InputMaybe<Scalars['NameID']>;
-  profileData: CreateProfileInput;
-  tags?: InputMaybe<Array<Scalars['String']>>;
   type?: InputMaybe<SpaceType>;
 };
 
 export type CreateSubspaceInput = {
+  about: CreateSpaceAboutInput;
   collaborationData: CreateCollaborationOnSpaceInput;
-  context?: InputMaybe<CreateContextInput>;
   /** A readable identifier, unique within the containing scope. */
   nameID?: InputMaybe<Scalars['NameID']>;
-  profileData: CreateProfileInput;
   spaceID: Scalars['UUID'];
-  tags?: InputMaybe<Array<Scalars['String']>>;
   type?: InputMaybe<SpaceType>;
 };
 
@@ -2159,6 +2063,7 @@ export type CredentialMetadataOutput = {
 };
 
 export enum CredentialType {
+  AccountAdmin = 'ACCOUNT_ADMIN',
   AccountLicensePlus = 'ACCOUNT_LICENSE_PLUS',
   BetaTester = 'BETA_TESTER',
   GlobalAdmin = 'GLOBAL_ADMIN',
@@ -2181,19 +2086,12 @@ export enum CredentialType {
   SpaceLicensePlus = 'SPACE_LICENSE_PLUS',
   SpaceLicensePremium = 'SPACE_LICENSE_PREMIUM',
   SpaceMember = 'SPACE_MEMBER',
+  SpaceMemberInvitee = 'SPACE_MEMBER_INVITEE',
   SpaceSubspaceAdmin = 'SPACE_SUBSPACE_ADMIN',
   UserGroupMember = 'USER_GROUP_MEMBER',
   UserSelfManagement = 'USER_SELF_MANAGEMENT',
   VcCampaign = 'VC_CAMPAIGN',
 }
-
-export type DeleteActorGroupInput = {
-  ID: Scalars['UUID'];
-};
-
-export type DeleteActorInput = {
-  ID: Scalars['UUID'];
-};
 
 export type DeleteAiPersonaServiceInput = {
   ID: Scalars['UUID'];
@@ -2224,7 +2122,7 @@ export type DeleteInnovationHubInput = {
 };
 
 export type DeleteInnovationPackInput = {
-  ID: Scalars['UUID_NAMEID'];
+  ID: Scalars['UUID'];
 };
 
 export type DeleteInvitationInput = {
@@ -2256,7 +2154,7 @@ export type DeleteReferenceInput = {
 };
 
 export type DeleteSpaceInput = {
-  ID: Scalars['UUID_NAMEID'];
+  ID: Scalars['UUID'];
 };
 
 export type DeleteStorageBuckeetInput = {
@@ -2277,7 +2175,7 @@ export type DeleteUserInput = {
 };
 
 export type DeleteVirtualContributorInput = {
-  ID: Scalars['UUID_NAMEID'];
+  ID: Scalars['UUID'];
 };
 
 export type DeleteWhiteboardInput = {
@@ -2359,21 +2257,6 @@ export type Document = {
   url: Scalars['String'];
 };
 
-export type EcosystemModel = {
-  /** A list of ActorGroups */
-  actorGroups?: Maybe<Array<ActorGroup>>;
-  /** The authorization rules for the entity */
-  authorization?: Maybe<Authorization>;
-  /** The date at which the entity was created. */
-  createdDate?: Maybe<Scalars['DateTime']>;
-  /** Overview of this ecosystem model. */
-  description?: Maybe<Scalars['String']>;
-  /** The ID of the entity */
-  id: Scalars['UUID'];
-  /** The date at which the entity was last updated. */
-  updatedDate?: Maybe<Scalars['DateTime']>;
-};
-
 export type ExploreSpacesInput = {
   /** Take into account only the activity in the past X days. */
   daysOld?: InputMaybe<Scalars['Float']>;
@@ -2436,7 +2319,7 @@ export type Forum = {
 };
 
 export type ForumDiscussionArgs = {
-  ID: Scalars['String'];
+  ID: Scalars['UUID'];
 };
 
 export type ForumDiscussionsArgs = {
@@ -2564,7 +2447,7 @@ export type InAppNotificationCommunityNewMember = InAppNotification & {
   /** Which category (role) is this notification targeted to. */
   category: InAppNotificationCategory;
   /** The type of the Contributor that joined. */
-  contributorType: CommunityContributorType;
+  contributorType: RoleSetContributorType;
   id: Scalars['UUID'];
   /** The receiver of the notification. */
   receiver: Contributor;
@@ -2596,7 +2479,7 @@ export type InAppNotificationUserMentioned = InAppNotification & {
   /** The url of the resource where the comment was created. */
   commentUrl: Scalars['String'];
   /** The type of the Contributor that joined. */
-  contributorType: CommunityContributorType;
+  contributorType: RoleSetContributorType;
   id: Scalars['UUID'];
   /** The receiver of the notification. */
   receiver: Contributor;
@@ -2621,14 +2504,23 @@ export type InnovationFlow = {
   id: Scalars['UUID'];
   /** The Profile for this InnovationFlow. */
   profile: Profile;
+  /** The settings for this InnovationFlow. */
+  settings: InnovationFlowSettings;
   /** The set of States in use in this Flow. */
   states: Array<InnovationFlowState>;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']>;
 };
 
+export type InnovationFlowSettings = {
+  /** The maximum number of allowed states. */
+  maximumNumberOfStates: Scalars['Float'];
+  /** The minimum number of allowed states */
+  minimumNumberOfStates: Scalars['Float'];
+};
+
 export type InnovationFlowState = {
-  /** The explation text to clarify the state. */
+  /** The explanation text to clarify the state. */
   description: Scalars['Markdown'];
   /** The display name for the State */
   displayName: Scalars['String'];
@@ -2744,12 +2636,12 @@ export type Invitation = {
   /** The Contributor who is invited. */
   contributor: Contributor;
   /** The type of contributor that is invited. */
-  contributorType: CommunityContributorType;
+  contributorType: RoleSetContributorType;
   /** The User who triggered the invitation. */
   createdBy: User;
   createdDate: Scalars['DateTime'];
   /** An additional role to assign to the Contributor, in addition to the entry Role. */
-  extraRole?: Maybe<CommunityRoleType>;
+  extraRole?: Maybe<RoleName>;
   /** The ID of the entity */
   id: Scalars['UUID'];
   /** Whether to also add the invited contributor to the parent community. */
@@ -2772,7 +2664,7 @@ export type InvitationEventInput = {
 
 export type InviteForEntryRoleOnRoleSetInput = {
   /** An additional role to assign to the Contributors, in addition to the entry Role. */
-  extraRole?: InputMaybe<CommunityRoleType>;
+  extraRole?: InputMaybe<RoleName>;
   /** The identifiers for the contributors being invited. */
   invitedContributors: Array<Scalars['UUID']>;
   roleSetID: Scalars['UUID'];
@@ -2784,7 +2676,7 @@ export type InviteNewContributorForRoleOnRoleSetInput = {
   firstName?: InputMaybe<Scalars['String']>;
   lastName?: InputMaybe<Scalars['String']>;
   /** An additional role to assign to the Contributors, in addition to the entry Role. */
-  roleSetExtraRole?: InputMaybe<CommunityRoleType>;
+  roleSetExtraRole?: InputMaybe<RoleName>;
   roleSetID: Scalars['UUID'];
   welcomeMessage?: InputMaybe<Scalars['String']>;
 };
@@ -3045,19 +2937,49 @@ export type Location = {
 };
 
 export type LookupByNameQueryResults = {
-  /** Lookup the specified InnovationPack using a NameID */
-  innovationPack?: Maybe<InnovationPack>;
-  /** Lookup the specified Template using a templatesSetId and the template NameID */
-  template?: Maybe<Template>;
+  /** Lookup the ID of the specified InnovationHub using a NameID */
+  innovationHub?: Maybe<Scalars['String']>;
+  /** Lookup the ID of the specified InnovationPack using a NameID */
+  innovationPack?: Maybe<Scalars['String']>;
+  /** Lookup the ID of the specified Organization using a NameID */
+  organization?: Maybe<Scalars['String']>;
+  /** Lookup a Space using a NameID */
+  space?: Maybe<Space>;
+  /** Lookup the ID of the specified Template using a templatesSetId and the template NameID */
+  template?: Maybe<Scalars['String']>;
+  /** Lookup the ID of the specified User using a NameID */
+  user?: Maybe<Scalars['String']>;
+  /** Lookup the ID of the specified Virtual Contributor using a NameID */
+  virtualContributor?: Maybe<Scalars['String']>;
+};
+
+export type LookupByNameQueryResultsInnovationHubArgs = {
+  NAMEID: Scalars['NameID'];
 };
 
 export type LookupByNameQueryResultsInnovationPackArgs = {
   NAMEID: Scalars['NameID'];
 };
 
+export type LookupByNameQueryResultsOrganizationArgs = {
+  NAMEID: Scalars['NameID'];
+};
+
+export type LookupByNameQueryResultsSpaceArgs = {
+  NAMEID: Scalars['NameID'];
+};
+
 export type LookupByNameQueryResultsTemplateArgs = {
   NAMEID: Scalars['NameID'];
   templatesSetID: Scalars['UUID'];
+};
+
+export type LookupByNameQueryResultsUserArgs = {
+  NAMEID: Scalars['NameID'];
+};
+
+export type LookupByNameQueryResultsVirtualContributorArgs = {
+  NAMEID: Scalars['NameID'];
 };
 
 export type LookupMyPrivilegesQueryResults = {
@@ -3077,8 +2999,6 @@ export type LookupMyPrivilegesQueryResults = {
   community?: Maybe<Array<AuthorizationPrivilege>>;
   /** Lookup myPrivileges on the specified Community guidelines */
   communityGuidelines?: Maybe<Array<AuthorizationPrivilege>>;
-  /** Lookup myPrivileges on the specified Context */
-  context?: Maybe<Array<AuthorizationPrivilege>>;
   /** Lookup myPrivileges on the specified Document */
   document?: Maybe<Array<AuthorizationPrivilege>>;
   /** Lookup myPrivileges on the specified InnovationFlow */
@@ -3101,6 +3021,8 @@ export type LookupMyPrivilegesQueryResults = {
   room?: Maybe<Array<AuthorizationPrivilege>>;
   /** Lookup myPrivileges on the specified Space */
   space?: Maybe<Array<AuthorizationPrivilege>>;
+  /** Lookup myPrivileges on the specified SpaceAbout */
+  spaceAbout?: Maybe<Array<AuthorizationPrivilege>>;
   /** Lookup myPrivileges on the specified StorageAggregator */
   storageAggregator?: Maybe<Array<AuthorizationPrivilege>>;
   /** Lookup myPrivileges on the specified StorageBucket */
@@ -3151,10 +3073,6 @@ export type LookupMyPrivilegesQueryResultsCommunityGuidelinesArgs = {
   ID: Scalars['UUID'];
 };
 
-export type LookupMyPrivilegesQueryResultsContextArgs = {
-  ID: Scalars['UUID'];
-};
-
 export type LookupMyPrivilegesQueryResultsDocumentArgs = {
   ID: Scalars['UUID'];
 };
@@ -3199,6 +3117,10 @@ export type LookupMyPrivilegesQueryResultsSpaceArgs = {
   ID: Scalars['UUID'];
 };
 
+export type LookupMyPrivilegesQueryResultsSpaceAboutArgs = {
+  ID: Scalars['UUID'];
+};
+
 export type LookupMyPrivilegesQueryResultsStorageAggregatorArgs = {
   ID: Scalars['UUID'];
 };
@@ -3232,6 +3154,8 @@ export type LookupMyPrivilegesQueryResultsWhiteboardArgs = {
 };
 
 export type LookupQueryResults = {
+  /** Lookup the specified SpaceAbout */
+  about?: Maybe<SpaceAbout>;
   /** Lookup the specified Account */
   account?: Maybe<Account>;
   /** Lookup the specified Application */
@@ -3254,8 +3178,6 @@ export type LookupQueryResults = {
   community?: Maybe<Community>;
   /** Lookup the specified Community guidelines */
   communityGuidelines?: Maybe<CommunityGuidelines>;
-  /** Lookup the specified Context */
-  context?: Maybe<Context>;
   /** Lookup the specified Document */
   document?: Maybe<Document>;
   /** Lookup the specified InnovationFlow */
@@ -3272,6 +3194,8 @@ export type LookupQueryResults = {
   license?: Maybe<License>;
   /** Lookup myPrivileges on the specified entity. */
   myPrivileges?: Maybe<LookupMyPrivilegesQueryResults>;
+  /** Lookup the specified Organization using a ID */
+  organization?: Maybe<Organization>;
   /** Lookup the specified Post */
   post?: Maybe<Post>;
   /** Lookup the specified Profile */
@@ -3298,6 +3222,10 @@ export type LookupQueryResults = {
   virtualContributor?: Maybe<VirtualContributor>;
   /** Lookup the specified Whiteboard */
   whiteboard?: Maybe<Whiteboard>;
+};
+
+export type LookupQueryResultsAboutArgs = {
+  ID: Scalars['UUID'];
 };
 
 export type LookupQueryResultsAccountArgs = {
@@ -3345,10 +3273,6 @@ export type LookupQueryResultsCommunityGuidelinesArgs = {
   ID: Scalars['UUID'];
 };
 
-export type LookupQueryResultsContextArgs = {
-  ID: Scalars['UUID'];
-};
-
 export type LookupQueryResultsDocumentArgs = {
   ID: Scalars['UUID'];
 };
@@ -3374,6 +3298,10 @@ export type LookupQueryResultsKnowledgeBaseArgs = {
 };
 
 export type LookupQueryResultsLicenseArgs = {
+  ID: Scalars['UUID'];
+};
+
+export type LookupQueryResultsOrganizationArgs = {
   ID: Scalars['UUID'];
 };
 
@@ -3434,6 +3362,8 @@ export type MeQueryResults = {
   communityApplications: Array<CommunityApplicationResult>;
   /** The invitations the current authenticated user can act on. */
   communityInvitations: Array<CommunityInvitationResult>;
+  /** The number of invitations the current authenticated user can act on. */
+  communityInvitationsCount: Scalars['Float'];
   /** The query id */
   id: Scalars['String'];
   /** The Spaces I am contributing to */
@@ -3454,7 +3384,15 @@ export type MeQueryResultsCommunityInvitationsArgs = {
   states?: InputMaybe<Array<Scalars['String']>>;
 };
 
+export type MeQueryResultsCommunityInvitationsCountArgs = {
+  states?: InputMaybe<Array<Scalars['String']>>;
+};
+
 export type MeQueryResultsMySpacesArgs = {
+  limit?: InputMaybe<Scalars['Float']>;
+};
+
+export type MeQueryResultsSpaceMembershipsHierarchicalArgs = {
   limit?: InputMaybe<Scalars['Float']>;
 };
 
@@ -3555,8 +3493,6 @@ export type Mutation = {
   aiServerCreateAiPersonaService: AiPersonaService;
   /** Deletes the specified AiPersonaService. */
   aiServerDeleteAiPersonaService: AiPersonaService;
-  /** Trigger an ingesting of data on the remove AI Persona Service. */
-  aiServerPersonaServiceIngest: Scalars['Boolean'];
   /** Updates the specified AI Persona. */
   aiServerUpdateAiPersonaService: AiPersonaService;
   /** Apply to join the specified RoleSet in the entry Role. */
@@ -3567,9 +3503,7 @@ export type Mutation = {
   assignLicensePlanToAccount: Account;
   /** Assign the specified LicensePlan to a Space. */
   assignLicensePlanToSpace: Space;
-  /** Assigns an Organization Role to user. */
-  assignOrganizationRoleToUser: User;
-  /** Assigns a platform role to a User. */
+  /** Assigns a User to a role on the Platform. */
   assignPlatformRoleToUser: User;
   /** Assigns an Organization a Role in the specified Community. */
   assignRoleToOrganization: Organization;
@@ -3603,12 +3537,8 @@ export type Mutation = {
   convertChallengeToSpace: Space;
   /** Creates a new Challenge by converting an existing Opportunity. */
   convertOpportunityToChallenge: Space;
-  /** Creates a new Actor in the specified ActorGroup. */
-  createActor: Actor;
-  /** Create a new Actor Group on the EcosystemModel. */
-  createActorGroup: ActorGroup;
-  /** Creates a new Callout on the specified CalloutsSet. */
-  createCallout: Callout;
+  /** Convert a VC of type ALKEMIO_SPACE to be of type KNOWLEDGE_BASE. All Callouts from the Space currently being used are moved to the Knowledge Base. Note: only allowed for VCs using a Space within the same Account. */
+  convertVirtualContributorToUseKnowledgeBase: VirtualContributor;
   /** Create a new Callout on the CalloutsSet. */
   createCalloutOnCalloutsSet: Callout;
   /** Create a guidance chat room. */
@@ -3649,10 +3579,8 @@ export type Mutation = {
   createUserNewRegistration: User;
   /** Creates a new VirtualContributor on an Account. */
   createVirtualContributor: VirtualContributor;
-  /** Deletes the specified Actor. */
-  deleteActor: Actor;
-  /** Deletes the specified Actor Group, including contained Actors. */
-  deleteActorGroup: ActorGroup;
+  /** Creates an account in Wingback */
+  createWingbackAccount: Scalars['String'];
   /** Deletes the specified CalendarEvent. */
   deleteCalendarEvent: CalendarEvent;
   /** Delete a Callout. */
@@ -3705,14 +3633,10 @@ export type Mutation = {
   grantCredentialToOrganization: Organization;
   /** Grants an authorization credential to a User. */
   grantCredentialToUser: User;
-  /** Resets the interaction with the chat engine. */
-  ingest: Scalars['Boolean'];
-  /** Invite an existing Contriburor to join the specified Community as a member. */
-  inviteContributorsForRoleSetMembership: Array<Invitation>;
+  /** Invite an existing Contributor to join the specified RoleSet in the Entry Role. */
+  inviteContributorsEntryRoleOnRoleSet: Array<Invitation>;
   /** Invite a User to join the platform and the specified RoleSet as a member. */
   inviteUserToPlatformAndRoleSet: PlatformInvitation;
-  /** Invite a User to join the platform in a particular Platform role e.g. BetaTester */
-  inviteUserToPlatformWithRole: PlatformInvitation;
   /** Join the specified RoleSet using the entry Role, without going through an approval process. */
   joinRoleSet: RoleSet;
   /** Reset the License with Entitlements on the specified Account. */
@@ -3729,9 +3653,7 @@ export type Mutation = {
   removeCommunityGuidelinesContent: CommunityGuidelines;
   /** Removes a message. */
   removeMessageOnRoom: Scalars['MessageID'];
-  /** Removes Organization Role from user. */
-  removeOrganizationRoleFromUser: User;
-  /** Removes a User from a platform role. */
+  /** Removes a User from a Role on the Platform. */
   removePlatformRoleFromUser: User;
   /** Remove a reaction on a message from the specified Room. */
   removeReactionToMessageInRoom: Scalars['Boolean'];
@@ -3765,6 +3687,8 @@ export type Mutation = {
   sendMessageToRoom: Message;
   /** Send message to a User. */
   sendMessageToUser: Scalars['Boolean'];
+  /** Transfer the specified Callout from its current CalloutsSet to the target CalloutsSet. Note: this is experimental, and only for GlobalAdmins. The user that executes the transfer becomes the creator of the Callout. */
+  transferCallout: Callout;
   /** Transfer the specified InnovationHub to another Account. */
   transferInnovationHubToAccount: InnovationHub;
   /** Transfer the specified Innovation Pack to another Account. */
@@ -3773,8 +3697,6 @@ export type Mutation = {
   transferSpaceToAccount: Space;
   /** Transfer the specified Virtual Contributor to another Account. */
   transferVirtualContributorToAccount: InnovationPack;
-  /** Updates the specified Actor. */
-  updateActor: Actor;
   /** Updates the specified AiPersona. */
   updateAiPersona: AiPersona;
   /** User vote if a specific answer is relevant. */
@@ -3801,8 +3723,6 @@ export type Mutation = {
   updateDiscussion: Discussion;
   /** Updates the specified Document. */
   updateDocument: Document;
-  /** Updates the specified EcosystemModel. */
-  updateEcosystemModel: EcosystemModel;
   /** Updates the InnovationFlow. */
   updateInnovationFlow: InnovationFlow;
   /** Updates the InnovationFlow. */
@@ -3825,6 +3745,8 @@ export type Mutation = {
   updateOrganizationPlatformSettings: Organization;
   /** Updates one of the Setting on an Organization */
   updateOrganizationSettings: Organization;
+  /** Updates one of the Setting on the Platform */
+  updatePlatformSettings: PlatformSettings;
   /** Updates the specified Post. */
   updatePost: Post;
   /** Updates one of the Preferences on a Space */
@@ -3857,6 +3779,8 @@ export type Mutation = {
   updateUserSettings: User;
   /** Updates the specified VirtualContributor. */
   updateVirtualContributor: VirtualContributor;
+  /** Updates one of the Setting on an Organization */
+  updateVirtualContributorSettings: VirtualContributor;
   /** Updates the image URI for the specified Visual. */
   updateVisual: Visual;
   /** Updates the specified Whiteboard. */
@@ -3907,10 +3831,6 @@ export type MutationAiServerDeleteAiPersonaServiceArgs = {
   deleteData: DeleteAiPersonaServiceInput;
 };
 
-export type MutationAiServerPersonaServiceIngestArgs = {
-  ingestData: AiPersonaServiceIngestInput;
-};
-
 export type MutationAiServerUpdateAiPersonaServiceArgs = {
   aiPersonaServiceData: UpdateAiPersonaServiceInput;
 };
@@ -3931,12 +3851,8 @@ export type MutationAssignLicensePlanToSpaceArgs = {
   planData: AssignLicensePlanToSpace;
 };
 
-export type MutationAssignOrganizationRoleToUserArgs = {
-  membershipData: AssignOrganizationRoleToUserInput;
-};
-
 export type MutationAssignPlatformRoleToUserArgs = {
-  membershipData: AssignPlatformRoleToUserInput;
+  roleData: AssignPlatformRoleInput;
 };
 
 export type MutationAssignRoleToOrganizationArgs = {
@@ -3988,16 +3904,8 @@ export type MutationConvertOpportunityToChallengeArgs = {
   convertData: ConvertSubsubspaceToSubspaceInput;
 };
 
-export type MutationCreateActorArgs = {
-  actorData: CreateActorInput;
-};
-
-export type MutationCreateActorGroupArgs = {
-  actorGroupData: CreateActorGroupInput;
-};
-
-export type MutationCreateCalloutArgs = {
-  calloutData: CreateCalloutOnCalloutsSetInput;
+export type MutationConvertVirtualContributorToUseKnowledgeBaseArgs = {
+  conversionData: ConversionVcSpaceToVcKnowledgeBaseInput;
 };
 
 export type MutationCreateCalloutOnCalloutsSetArgs = {
@@ -4072,12 +3980,8 @@ export type MutationCreateVirtualContributorArgs = {
   virtualContributorData: CreateVirtualContributorOnAccountInput;
 };
 
-export type MutationDeleteActorArgs = {
-  deleteData: DeleteActorInput;
-};
-
-export type MutationDeleteActorGroupArgs = {
-  deleteData: DeleteActorGroupInput;
+export type MutationCreateWingbackAccountArgs = {
+  accountID: Scalars['UUID'];
 };
 
 export type MutationDeleteCalendarEventArgs = {
@@ -4184,16 +4088,12 @@ export type MutationGrantCredentialToUserArgs = {
   grantCredentialData: GrantAuthorizationCredentialInput;
 };
 
-export type MutationInviteContributorsForRoleSetMembershipArgs = {
+export type MutationInviteContributorsEntryRoleOnRoleSetArgs = {
   invitationData: InviteForEntryRoleOnRoleSetInput;
 };
 
 export type MutationInviteUserToPlatformAndRoleSetArgs = {
   invitationData: InviteNewContributorForRoleOnRoleSetInput;
-};
-
-export type MutationInviteUserToPlatformWithRoleArgs = {
-  invitationData: CreatePlatformInvitationForRoleInput;
 };
 
 export type MutationJoinRoleSetArgs = {
@@ -4224,12 +4124,8 @@ export type MutationRemoveMessageOnRoomArgs = {
   messageData: RoomRemoveMessageInput;
 };
 
-export type MutationRemoveOrganizationRoleFromUserArgs = {
-  membershipData: RemoveOrganizationRoleFromUserInput;
-};
-
 export type MutationRemovePlatformRoleFromUserArgs = {
-  membershipData: RemovePlatformRoleFromUserInput;
+  roleData: RemovePlatformRoleInput;
 };
 
 export type MutationRemoveReactionToMessageInRoomArgs = {
@@ -4288,6 +4184,10 @@ export type MutationSendMessageToUserArgs = {
   messageData: CommunicationSendMessageToUserInput;
 };
 
+export type MutationTransferCalloutArgs = {
+  transferData: TransferCalloutInput;
+};
+
 export type MutationTransferInnovationHubToAccountArgs = {
   transferData: TransferAccountInnovationHubInput;
 };
@@ -4302,10 +4202,6 @@ export type MutationTransferSpaceToAccountArgs = {
 
 export type MutationTransferVirtualContributorToAccountArgs = {
   transferData: TransferAccountVirtualContributorInput;
-};
-
-export type MutationUpdateActorArgs = {
-  actorData: UpdateActorInput;
 };
 
 export type MutationUpdateAiPersonaArgs = {
@@ -4360,10 +4256,6 @@ export type MutationUpdateDocumentArgs = {
   documentData: UpdateDocumentInput;
 };
 
-export type MutationUpdateEcosystemModelArgs = {
-  ecosystemModelData: UpdateEcosystemModelInput;
-};
-
 export type MutationUpdateInnovationFlowArgs = {
   innovationFlowData: UpdateInnovationFlowEntityInput;
 };
@@ -4406,6 +4298,10 @@ export type MutationUpdateOrganizationPlatformSettingsArgs = {
 
 export type MutationUpdateOrganizationSettingsArgs = {
   settingsData: UpdateOrganizationSettingsInput;
+};
+
+export type MutationUpdatePlatformSettingsArgs = {
+  settingsData: UpdatePlatformSettingsInput;
 };
 
 export type MutationUpdatePostArgs = {
@@ -4470,6 +4366,10 @@ export type MutationUpdateUserSettingsArgs = {
 
 export type MutationUpdateVirtualContributorArgs = {
   virtualContributorData: UpdateVirtualContributorInput;
+};
+
+export type MutationUpdateVirtualContributorSettingsArgs = {
+  settingsData: UpdateVirtualContributorSettingsInput;
 };
 
 export type MutationUpdateVisualArgs = {
@@ -4555,12 +4455,8 @@ export type Organization = Contributor &
   Groupable & {
     /** The account hosted by this Organization. */
     account?: Maybe<Account>;
-    /** All Users that are admins of this Organization. */
-    admins?: Maybe<Array<User>>;
     /** The Agent representing this User. */
     agent: Agent;
-    /** All Users that are associated with this Organization. */
-    associates?: Maybe<Array<User>>;
     /** The authorization rules for the Contributor */
     authorization?: Maybe<Authorization>;
     /** Organization contact email */
@@ -4579,14 +4475,12 @@ export type Organization = Contributor &
     legalEntityName?: Maybe<Scalars['String']>;
     /** Metrics about the activity within this Organization. */
     metrics?: Maybe<Array<Nvp>>;
-    /** The roles on this Organization for the currently logged in user. */
-    myRoles?: Maybe<Array<OrganizationRole>>;
     /** A name identifier of the Contributor, unique within a given scope. */
     nameID: Scalars['NameID'];
-    /** All Users that are owners of this Organization. */
-    owners?: Maybe<Array<User>>;
     /** The profile for this Organization. */
     profile: Profile;
+    /** The RoleSet for this Organization. */
+    roleSet: RoleSet;
     /** The settings for this Organization. */
     settings: OrganizationSettings;
     /** The StorageAggregator for managing storage buckets in use by this Organization */
@@ -4614,12 +4508,6 @@ export type OrganizationFilterInput = {
   nameID?: InputMaybe<Scalars['String']>;
   website?: InputMaybe<Scalars['String']>;
 };
-
-export enum OrganizationRole {
-  Admin = 'ADMIN',
-  Associate = 'ASSOCIATE',
-  Owner = 'OWNER',
-}
 
 export type OrganizationSettings = {
   /** The membership settings for this Organization. */
@@ -4668,6 +4556,11 @@ export type OrganizationVerificationEventInput = {
   organizationVerificationID: Scalars['UUID'];
 };
 
+export type OrganizationsInRolesResponse = {
+  organizations: Array<Organization>;
+  role: RoleName;
+};
+
 export type OryConfig = {
   /** Ory Issuer. */
   issuer: Scalars['String'];
@@ -4707,6 +4600,8 @@ export type PaginatedUsers = {
 export type Platform = {
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
+  /** The Virtual Contributor that is used to provide chat help on the platform. */
+  chatGuidanceVirtualContributor: VirtualContributor;
   /** Alkemio configuration. Provides configuration to external services in the Alkemio ecosystem. */
   configuration: Config;
   /** The date at which the entity was created. */
@@ -4725,10 +4620,10 @@ export type Platform = {
   licensingFramework: Licensing;
   /** Alkemio Services Metadata. */
   metadata: Metadata;
-  /** The roles on the Platform for the currently logged in user. */
-  myRoles: Array<PlatformRole>;
-  /** Invitations to join roles for users not yet on the Alkemio platform. */
-  platformInvitations: Array<PlatformInvitation>;
+  /** The RoleSet for this Platform. */
+  roleSet: RoleSet;
+  /** The settings of the Platform. */
+  settings: PlatformSettings;
   /** The StorageAggregator with documents in use by Users + Organizations on the Platform. */
   storageAggregator: StorageAggregator;
   /** The TemplatesManager in use by the Platform */
@@ -4738,7 +4633,7 @@ export type Platform = {
 };
 
 export type PlatformInnovationHubArgs = {
-  id?: InputMaybe<Scalars['UUID_NAMEID']>;
+  id?: InputMaybe<Scalars['UUID']>;
   subdomain?: InputMaybe<Scalars['String']>;
 };
 
@@ -4760,10 +4655,15 @@ export enum PlatformFeatureFlagName {
   Whiteboards = 'WHITEBOARDS',
 }
 
+export type PlatformIntegrationSettings = {
+  /** The list of allowed URLs for iFrames within Markdown content. */
+  iframeAllowedUrls: Array<Scalars['String']>;
+};
+
 export type PlatformInvitation = {
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
-  /** The User who triggered the platformInvitation. */
+  /** The User who created the platformInvitation. */
   createdBy: User;
   /** The date at which the entity was created. */
   createdDate?: Maybe<Scalars['DateTime']>;
@@ -4774,11 +4674,11 @@ export type PlatformInvitation = {
   id: Scalars['UUID'];
   lastName?: Maybe<Scalars['String']>;
   /** The platform role the user will receive when they sign up */
-  platformRole?: Maybe<PlatformRole>;
+  platformRole?: Maybe<RoleName>;
   /** Whether a new user profile has been created. */
   profileCreated: Scalars['Boolean'];
   /** An additional role to assign to the Contributor, in addition to the entry Role. */
-  roleSetExtraRole?: Maybe<CommunityRoleType>;
+  roleSetExtraRole?: Maybe<RoleName>;
   /** Whether to also add the invited user to the parent community. */
   roleSetInvitedToParent: Scalars['Boolean'];
   /** The date at which the entity was last updated. */
@@ -4839,15 +4739,10 @@ export type PlatformLocations = {
   tips: Scalars['String'];
 };
 
-export enum PlatformRole {
-  BetaTester = 'BETA_TESTER',
-  CommunityReader = 'COMMUNITY_READER',
-  GlobalAdmin = 'GLOBAL_ADMIN',
-  LicenseManager = 'LICENSE_MANAGER',
-  SpacesReader = 'SPACES_READER',
-  Support = 'SUPPORT',
-  VcCampaign = 'VC_CAMPAIGN',
-}
+export type PlatformSettings = {
+  /** The integration settings for this Platform */
+  integration: PlatformIntegrationSettings;
+};
 
 export type Post = {
   /** The authorization rules for the entity */
@@ -4992,7 +4887,6 @@ export type ProfileCredentialVerified = {
 export enum ProfileType {
   CalendarEvent = 'CALENDAR_EVENT',
   CalloutFraming = 'CALLOUT_FRAMING',
-  Challenge = 'CHALLENGE',
   CommunityGuidelines = 'COMMUNITY_GUIDELINES',
   ContributionLink = 'CONTRIBUTION_LINK',
   Discussion = 'DISCUSSION',
@@ -5000,10 +4894,9 @@ export enum ProfileType {
   InnovationHub = 'INNOVATION_HUB',
   InnovationPack = 'INNOVATION_PACK',
   KnowledgeBase = 'KNOWLEDGE_BASE',
-  Opportunity = 'OPPORTUNITY',
   Organization = 'ORGANIZATION',
   Post = 'POST',
-  Space = 'SPACE',
+  SpaceAbout = 'SPACE_ABOUT',
   Template = 'TEMPLATE',
   User = 'USER',
   UserGroup = 'USER_GROUP',
@@ -5013,8 +4906,6 @@ export enum ProfileType {
 }
 
 export type Query = {
-  /** An account. If no ID is specified then the first Account is returned. */
-  account: Account;
   /** The Accounts on this platform; If accessed through an Innovation Hub will return ONLY the Accounts defined in it. */
   accounts: Array<Account>;
   /** Activity events related to the current user. */
@@ -5041,7 +4932,7 @@ export type Query = {
   lookupByName: LookupByNameQueryResults;
   /** Information about the current authenticated user */
   me: MeQueryResults;
-  /** Get all notifications for a receiver. */
+  /** Get all notifications for the logged in user. */
   notifications: Array<InAppNotification>;
   /** A particular Organization */
   organization: Organization;
@@ -5059,8 +4950,6 @@ export type Query = {
   rolesVirtualContributor: ContributorRoles;
   /** Search the platform for terms supplied */
   search: ISearchResults;
-  /** Look up a top level Space (i.e. a Space that does not have a parent Space) by the UUID or NameID. */
-  space: Space;
   /** The Spaces on this platform; If accessed through an Innovation Hub will return ONLY the Spaces defined in it. */
   spaces: Array<Space>;
   /** The Spaces on this platform */
@@ -5069,6 +4958,8 @@ export type Query = {
   task: Task;
   /** All tasks with filtering applied */
   tasks: Array<Task>;
+  /** Allow resolving of a URL into a set of IDs. */
+  urlResolver: UrlResolverQueryResults;
   /** A particular user, identified by the ID or by email */
   user: User;
   /** Privileges assigned to a User (based on held credentials) given an Authorization defnition. */
@@ -5081,12 +4972,8 @@ export type Query = {
   usersWithAuthorizationCredential: Array<User>;
   /** A particular VirtualContributor */
   virtualContributor: VirtualContributor;
-  /** The VirtualContributors on this platform */
+  /** The VirtualContributors on this platform; only accessible to platform admins */
   virtualContributors: Array<VirtualContributor>;
-};
-
-export type QueryAccountArgs = {
-  ID: Scalars['UUID_NAMEID'];
 };
 
 export type QueryActivityFeedArgs = {
@@ -5113,12 +5000,8 @@ export type QueryExploreSpacesArgs = {
   options?: InputMaybe<ExploreSpacesInput>;
 };
 
-export type QueryNotificationsArgs = {
-  receiverID: Scalars['UUID'];
-};
-
 export type QueryOrganizationArgs = {
-  ID: Scalars['UUID_NAMEID'];
+  ID: Scalars['UUID'];
 };
 
 export type QueryOrganizationsArgs = {
@@ -5152,10 +5035,6 @@ export type QuerySearchArgs = {
   searchData: SearchInput;
 };
 
-export type QuerySpaceArgs = {
-  ID: Scalars['UUID_NAMEID'];
-};
-
 export type QuerySpacesArgs = {
   IDs?: InputMaybe<Array<Scalars['UUID']>>;
   filter?: InputMaybe<SpaceFilterInput>;
@@ -5177,8 +5056,12 @@ export type QueryTasksArgs = {
   status?: InputMaybe<TaskStatus>;
 };
 
+export type QueryUrlResolverArgs = {
+  url: Scalars['String'];
+};
+
 export type QueryUserArgs = {
-  ID: Scalars['UUID_NAMEID_EMAIL'];
+  ID: Scalars['UUID'];
 };
 
 export type QueryUserAuthorizationPrivilegesArgs = {
@@ -5206,7 +5089,7 @@ export type QueryUsersWithAuthorizationCredentialArgs = {
 };
 
 export type QueryVirtualContributorArgs = {
-  ID: Scalars['UUID_NAMEID'];
+  ID: Scalars['UUID'];
 };
 
 export type QueryVirtualContributorsArgs = {
@@ -5261,6 +5144,8 @@ export type RefreshVirtualContributorBodyOfKnowledgeInput = {
 };
 
 export type RelayPaginatedSpace = {
+  /** About this space. */
+  about: SpaceAbout;
   /** The Account that this Space is part of. */
   account: Account;
   /** The "highest" subscription active for this Space. */
@@ -5273,8 +5158,6 @@ export type RelayPaginatedSpace = {
   collaboration: Collaboration;
   /** Get the Community for the Space.  */
   community: Community;
-  /** The context for the space. */
-  context: Context;
   /** The date at which the entity was created. */
   createdDate?: Maybe<Scalars['DateTime']>;
   /** The ID of the entity */
@@ -5289,8 +5172,6 @@ export type RelayPaginatedSpace = {
   metrics?: Maybe<Array<Nvp>>;
   /** A name identifier of the entity, unique within a given scope. */
   nameID: Scalars['NameID'];
-  /** The Profile for the Space. */
-  profile: Profile;
   /** The Space provider. */
   provider: Contributor;
   /** The settings for this Space. */
@@ -5299,8 +5180,8 @@ export type RelayPaginatedSpace = {
   storageAggregator: StorageAggregator;
   /** The subscriptions active for this Space. */
   subscriptions: Array<SpaceSubscription>;
-  /** A particular subspace, either by its ID or nameID */
-  subspace: Space;
+  /** A particular subspace by its nameID */
+  subspaceByNameID: Space;
   /** The subspaces for the space. */
   subspaces: Array<Space>;
   /** The TemplatesManager in use by this Space */
@@ -5313,8 +5194,8 @@ export type RelayPaginatedSpace = {
   visibility: SpaceVisibility;
 };
 
-export type RelayPaginatedSpaceSubspaceArgs = {
-  ID: Scalars['UUID_NAMEID'];
+export type RelayPaginatedSpaceSubspaceByNameIdArgs = {
+  NAMEID: Scalars['NameID'];
 };
 
 export type RelayPaginatedSpaceSubspacesArgs = {
@@ -5343,32 +5224,26 @@ export type RemoveCommunityGuidelinesContentInput = {
   communityGuidelinesID: Scalars['UUID'];
 };
 
-export type RemoveOrganizationRoleFromUserInput = {
-  organizationID: Scalars['UUID'];
-  role: OrganizationRole;
-  userID: Scalars['UUID'];
-};
-
-export type RemovePlatformRoleFromUserInput = {
-  role: PlatformRole;
-  userID: Scalars['UUID'];
+export type RemovePlatformRoleInput = {
+  contributorID: Scalars['UUID'];
+  role: RoleName;
 };
 
 export type RemoveRoleOnRoleSetFromOrganizationInput = {
   contributorID: Scalars['UUID'];
-  role: CommunityRoleType;
+  role: RoleName;
   roleSetID: Scalars['UUID'];
 };
 
 export type RemoveRoleOnRoleSetFromUserInput = {
   contributorID: Scalars['UUID'];
-  role: CommunityRoleType;
+  role: RoleName;
   roleSetID: Scalars['UUID'];
 };
 
 export type RemoveRoleOnRoleSetFromVirtualContributorInput = {
   contributorID: Scalars['UUID'];
-  role: CommunityRoleType;
+  role: RoleName;
   roleSetID: Scalars['UUID'];
 };
 
@@ -5418,6 +5293,8 @@ export type Role = {
   credential: CredentialDefinition;
   /** The ID of the entity */
   id: Scalars['UUID'];
+  /** The CommunityRole that this role definition is for. */
+  name: RoleName;
   /** The role policy that applies for Organizations in this Role. */
   organizationPolicy: ContributorRolePolicy;
   /** The Credential associated with this Role. */
@@ -5426,8 +5303,6 @@ export type Role = {
   requiresEntryRole: Scalars['Boolean'];
   /** Flag to indicate if this Role requires having the same role in the Parent RoleSet. */
   requiresSameRoleInParentRoleSet: Scalars['Boolean'];
-  /** The CommunityRole that this role definition is for. */
-  type: CommunityRoleType;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']>;
   /** The role policy that applies for Users in this Role. */
@@ -5436,21 +5311,36 @@ export type Role = {
   virtualContributorPolicy: ContributorRolePolicy;
 };
 
+export enum RoleName {
+  Admin = 'ADMIN',
+  Associate = 'ASSOCIATE',
+  GlobalAdmin = 'GLOBAL_ADMIN',
+  GlobalCommunityReader = 'GLOBAL_COMMUNITY_READER',
+  GlobalLicenseManager = 'GLOBAL_LICENSE_MANAGER',
+  GlobalSpacesReader = 'GLOBAL_SPACES_READER',
+  GlobalSupport = 'GLOBAL_SUPPORT',
+  Lead = 'LEAD',
+  Member = 'MEMBER',
+  Owner = 'OWNER',
+  PlatformBetaTester = 'PLATFORM_BETA_TESTER',
+  PlatformVcCampaign = 'PLATFORM_VC_CAMPAIGN',
+}
+
 export type RoleSet = {
   /** The Form used for Applications to this roleSet. */
   applicationForm: Form;
-  /** Applications available for this roleSet. */
+  /** Applications available for this RoleSet. */
   applications: Array<Application>;
   /** The authorization rules for the entity */
   authorization?: Maybe<Authorization>;
-  /** All  users excluding the current lead users in this Community. */
-  availableUsersForLeadRole: PaginatedUsers;
-  /** All available users that are potential Community members. */
-  availableUsersForMemberRole: PaginatedUsers;
+  /** All users that have the entryRole in the RoleSet, minus those already in the specified role. */
+  availableUsersForElevatedRole: PaginatedUsers;
+  /** All available users that are could join this RoleSet in the entry role. */
+  availableUsersForEntryRole: PaginatedUsers;
   /** The date at which the entity was created. */
   createdDate?: Maybe<Scalars['DateTime']>;
-  /** The CommunityRole that acts as the entry Role for the RoleSet, so other roles potentially require it. */
-  entryRoleType: CommunityRoleType;
+  /** The Role that acts as the entry Role for the RoleSet, so other roles potentially require it. */
+  entryRoleName: RoleName;
   /** The ID of the entity */
   id: Scalars['UUID'];
   /** Invitations for this roleSet. */
@@ -5460,34 +5350,45 @@ export type RoleSet = {
   /** The membership status of the currently logged in user. */
   myMembershipStatus?: Maybe<CommunityMembershipStatus>;
   /** The roles on this community for the currently logged in user. */
-  myRoles: Array<CommunityRoleType>;
+  myRoles: Array<RoleName>;
   /** The implicit roles on this community for the currently logged in user. */
-  myRolesImplicit: Array<CommunityRoleImplicit>;
+  myRolesImplicit: Array<RoleSetRoleImplicit>;
   /** All Organizations that have the specified Role in this Community. */
   organizationsInRole: Array<Organization>;
-  /** Invitations to join this Community for users not yet on the Alkemio platform. */
+  /** All organizations that have a role in this RoleSet in the specified Roles. */
+  organizationsInRoles: Array<OrganizationsInRolesResponse>;
+  /** Invitations to join this RoleSet in an entry role for users not yet on the Alkemio platform. */
   platformInvitations: Array<PlatformInvitation>;
   /** The Role Definitions from this RoleSet to return. */
   roleDefinition: Role;
   /** The Role Definitions included in this roleSet. */
   roleDefinitions: Array<Role>;
+  /** The Roles available in this roleSet. */
+  roleNames: Array<RoleName>;
+  /** A type of entity that this RoleSet is being used with. */
+  type?: Maybe<RoleSetType>;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']>;
   /** All users that are contributing to this Community in the specified Role. */
   usersInRole: Array<User>;
+  /** All users that have a Role in this RoleSet in the specified Roles. */
+  usersInRoles: Array<UsersInRolesResponse>;
   /** All virtuals that have the specified Role in this Community. */
   virtualContributorsInRole: Array<VirtualContributor>;
+  /** All VirtualContributors that have a role in this RoleSet in the specified Roles. */
+  virtualContributorsInRoles: Array<VirtualContributorsInRolesResponse>;
 };
 
-export type RoleSetAvailableUsersForLeadRoleArgs = {
+export type RoleSetAvailableUsersForElevatedRoleArgs = {
   after?: InputMaybe<Scalars['UUID']>;
   before?: InputMaybe<Scalars['UUID']>;
   filter?: InputMaybe<UserFilterInput>;
   first?: InputMaybe<Scalars['Int']>;
   last?: InputMaybe<Scalars['Int']>;
+  role: RoleName;
 };
 
-export type RoleSetAvailableUsersForMemberRoleArgs = {
+export type RoleSetAvailableUsersForEntryRoleArgs = {
   after?: InputMaybe<Scalars['UUID']>;
   before?: InputMaybe<Scalars['UUID']>;
   filter?: InputMaybe<UserFilterInput>;
@@ -5496,27 +5397,61 @@ export type RoleSetAvailableUsersForMemberRoleArgs = {
 };
 
 export type RoleSetOrganizationsInRoleArgs = {
-  role: CommunityRoleType;
+  role: RoleName;
+};
+
+export type RoleSetOrganizationsInRolesArgs = {
+  roles: Array<RoleName>;
 };
 
 export type RoleSetRoleDefinitionArgs = {
-  role: CommunityRoleType;
+  role: RoleName;
+};
+
+export type RoleSetRoleDefinitionsArgs = {
+  roles?: InputMaybe<Array<RoleName>>;
 };
 
 export type RoleSetUsersInRoleArgs = {
   limit?: InputMaybe<Scalars['Float']>;
-  role: CommunityRoleType;
+  role: RoleName;
+};
+
+export type RoleSetUsersInRolesArgs = {
+  limit?: InputMaybe<Scalars['Float']>;
+  roles: Array<RoleName>;
 };
 
 export type RoleSetVirtualContributorsInRoleArgs = {
-  role: CommunityRoleType;
+  role: RoleName;
 };
+
+export type RoleSetVirtualContributorsInRolesArgs = {
+  roles: Array<RoleName>;
+};
+
+export enum RoleSetContributorType {
+  Organization = 'ORGANIZATION',
+  User = 'USER',
+  Virtual = 'VIRTUAL',
+}
+
+export enum RoleSetRoleImplicit {
+  AccountAdmin = 'ACCOUNT_ADMIN',
+  SubspaceAdmin = 'SUBSPACE_ADMIN',
+}
+
+export enum RoleSetType {
+  Organization = 'ORGANIZATION',
+  Platform = 'PLATFORM',
+  Space = 'SPACE',
+}
 
 export type RolesOrganizationInput = {
   /** Return membership in Spaces matching the provided filter. */
   filter?: InputMaybe<SpaceFilterInput>;
   /** The ID of the organization to retrieve the roles of. */
-  organizationID: Scalars['UUID_NAMEID'];
+  organizationID: Scalars['UUID'];
 };
 
 export type RolesResult = {
@@ -5585,12 +5520,12 @@ export type RolesUserInput = {
   /** Return membership in Spaces matching the provided filter. */
   filter?: InputMaybe<SpaceFilterInput>;
   /** The ID of the user to retrieve the roles of. */
-  userID: Scalars['UUID_NAMEID_EMAIL'];
+  userID: Scalars['UUID'];
 };
 
 export type RolesVirtualContributorInput = {
   /** The ID or nameID of the VC to retrieve the roles of. */
-  virtualContributorID: Scalars['UUID_NAMEID'];
+  virtualContributorID: Scalars['UUID'];
 };
 
 export type Room = {
@@ -5681,7 +5616,7 @@ export type RoomSendMessageReplyInput = {
 
 export type SearchInput = {
   /** Restrict the search to only the specified Space. Default is all Spaces. */
-  searchInSpaceFilter?: InputMaybe<Scalars['UUID_NAMEID']>;
+  searchInSpaceFilter?: InputMaybe<Scalars['UUID']>;
   /** Expand the search to includes Tagsets with the provided names. Max 2. */
   tagsetNames?: InputMaybe<Array<Scalars['String']>>;
   /** The terms to be searched for within this Space. Max 5. */
@@ -5818,6 +5753,8 @@ export type ServiceMetadata = {
 };
 
 export type Space = {
+  /** About this space. */
+  about: SpaceAbout;
   /** The Account that this Space is part of. */
   account: Account;
   /** The "highest" subscription active for this Space. */
@@ -5830,8 +5767,6 @@ export type Space = {
   collaboration: Collaboration;
   /** Get the Community for the Space.  */
   community: Community;
-  /** The context for the space. */
-  context: Context;
   /** The date at which the entity was created. */
   createdDate?: Maybe<Scalars['DateTime']>;
   /** The ID of the entity */
@@ -5846,8 +5781,6 @@ export type Space = {
   metrics?: Maybe<Array<Nvp>>;
   /** A name identifier of the entity, unique within a given scope. */
   nameID: Scalars['NameID'];
-  /** The Profile for the Space. */
-  profile: Profile;
   /** The Space provider. */
   provider: Contributor;
   /** The settings for this Space. */
@@ -5856,8 +5789,8 @@ export type Space = {
   storageAggregator: StorageAggregator;
   /** The subscriptions active for this Space. */
   subscriptions: Array<SpaceSubscription>;
-  /** A particular subspace, either by its ID or nameID */
-  subspace: Space;
+  /** A particular subspace by its nameID */
+  subspaceByNameID: Space;
   /** The subspaces for the space. */
   subspaces: Array<Space>;
   /** The TemplatesManager in use by this Space */
@@ -5870,8 +5803,8 @@ export type Space = {
   visibility: SpaceVisibility;
 };
 
-export type SpaceSubspaceArgs = {
-  ID: Scalars['UUID_NAMEID'];
+export type SpaceSubspaceByNameIdArgs = {
+  NAMEID: Scalars['NameID'];
 };
 
 export type SpaceSubspacesArgs = {
@@ -5880,28 +5813,43 @@ export type SpaceSubspacesArgs = {
   shuffle?: InputMaybe<Scalars['Boolean']>;
 };
 
+export type SpaceAbout = {
+  /** The authorization rules for the entity */
+  authorization?: Maybe<Authorization>;
+  /** The date at which the entity was created. */
+  createdDate?: Maybe<Scalars['DateTime']>;
+  /** The ID of the entity */
+  id: Scalars['UUID'];
+  /** The Profile for the Space. */
+  profile: Profile;
+  /** The date at which the entity was last updated. */
+  updatedDate?: Maybe<Scalars['DateTime']>;
+  /** Who should get involved in this challenge */
+  who?: Maybe<Scalars['Markdown']>;
+  /** The goal that is being pursued */
+  why?: Maybe<Scalars['Markdown']>;
+};
+
 export type SpaceFilterInput = {
   /** Return Spaces with a Visibility matching one of the provided types. */
   visibilities?: InputMaybe<Array<SpaceVisibility>>;
 };
 
 export enum SpaceLevel {
-  Challenge = 'CHALLENGE',
-  Opportunity = 'OPPORTUNITY',
-  Space = 'SPACE',
+  L0 = 'L0',
+  L1 = 'L1',
+  L2 = 'L2',
 }
 
 export type SpacePendingMembershipInfo = {
+  /** About the Space */
+  about: SpaceAbout;
   /** The CommunityGuidelines for the Space */
   communityGuidelines: CommunityGuidelines;
-  /** The Context of the Space */
-  context: Context;
   /** The Space ID */
   id: Scalars['UUID'];
   /** The Level of the Space */
   level: SpaceLevel;
-  /** The Profile of the Space */
-  profile: Profile;
 };
 
 export enum SpacePrivacyMode {
@@ -6033,11 +5981,11 @@ export type StorageBucket = {
 };
 
 export type StorageBucketDocumentArgs = {
-  ID: Scalars['UUID_NAMEID'];
+  ID: Scalars['UUID'];
 };
 
 export type StorageBucketDocumentsArgs = {
-  IDs?: InputMaybe<Array<Scalars['UUID_NAMEID']>>;
+  IDs?: InputMaybe<Array<Scalars['UUID']>>;
   limit?: InputMaybe<Scalars['Float']>;
 };
 
@@ -6108,7 +6056,7 @@ export type SubscriptionSubspaceCreatedArgs = {
 };
 
 export type SubscriptionVirtualContributorUpdatedArgs = {
-  virtualContributorID: Scalars['UUID_NAMEID'];
+  virtualContributorID: Scalars['UUID'];
 };
 
 export type SubspaceCreated = {
@@ -6360,12 +6308,11 @@ export type TransferAccountVirtualContributorInput = {
   virtualContributorID: Scalars['UUID'];
 };
 
-export type UpdateActorInput = {
-  ID: Scalars['UUID'];
-  description?: InputMaybe<Scalars['String']>;
-  impact?: InputMaybe<Scalars['String']>;
-  name?: InputMaybe<Scalars['String']>;
-  value?: InputMaybe<Scalars['String']>;
+export type TransferCalloutInput = {
+  /** The Callout to be transferred. */
+  calloutID: Scalars['UUID'];
+  /** The target CalloutsSet to which the Callout will be transferred. */
+  targetCalloutsSetID: Scalars['UUID'];
 };
 
 export type UpdateAiPersonaInput = {
@@ -6374,6 +6321,8 @@ export type UpdateAiPersonaInput = {
 
 export type UpdateAiPersonaServiceInput = {
   ID: Scalars['UUID'];
+  bodyOfKnowledgeID?: InputMaybe<Scalars['UUID']>;
+  bodyOfKnowledgeType?: InputMaybe<AiPersonaBodyOfKnowledgeType>;
   engine?: InputMaybe<AiPersonaEngine>;
   externalConfig?: InputMaybe<ExternalConfig>;
   prompt?: InputMaybe<Array<Scalars['String']>>;
@@ -6457,7 +6406,7 @@ export type UpdateCalloutVisibilityInput = {
 
 export type UpdateCalloutsSortOrderInput = {
   /** The IDs of the callouts to update the sort order on */
-  calloutIDs: Array<Scalars['UUID_NAMEID']>;
+  calloutIDs: Array<Scalars['UUID']>;
   calloutsSetID: Scalars['UUID'];
 };
 
@@ -6475,12 +6424,6 @@ export type UpdateCommunityGuidelinesEntityInput = {
   communityGuidelinesID: Scalars['UUID'];
   /** The Profile for this community guidelines. */
   profile: UpdateProfileInput;
-};
-
-export type UpdateContextInput = {
-  impact?: InputMaybe<Scalars['Markdown']>;
-  vision?: InputMaybe<Scalars['Markdown']>;
-  who?: InputMaybe<Scalars['Markdown']>;
 };
 
 export type UpdateContributionCalloutsSortOrderInput = {
@@ -6506,11 +6449,6 @@ export type UpdateDocumentInput = {
   tagset?: InputMaybe<UpdateTagsetInput>;
 };
 
-export type UpdateEcosystemModelInput = {
-  ID: Scalars['UUID'];
-  description?: InputMaybe<Scalars['String']>;
-};
-
 export type UpdateFormInput = {
   description: Scalars['Markdown'];
   questions: Array<UpdateFormQuestionInput>;
@@ -6532,12 +6470,6 @@ export type UpdateFormQuestionInput = {
 export type UpdateInnovationFlowEntityInput = {
   /** ID of the Innovation Flow */
   innovationFlowID: Scalars['UUID'];
-  /** The Profile of this entity. */
-  profileData?: InputMaybe<UpdateProfileInput>;
-  states?: InputMaybe<Array<UpdateInnovationFlowStateInput>>;
-};
-
-export type UpdateInnovationFlowInput = {
   /** The Profile of this entity. */
   profileData?: InputMaybe<UpdateProfileInput>;
   states?: InputMaybe<Array<UpdateInnovationFlowStateInput>>;
@@ -6576,7 +6508,7 @@ export type UpdateInnovationHubInput = {
   /** Visibility of the InnovationHub in searches. */
   searchVisibility?: InputMaybe<SearchVisibility>;
   /** A list of Spaces to include in this Innovation Hub. Only valid when type 'list' is used. */
-  spaceListFilter?: InputMaybe<Array<Scalars['UUID_NAMEID']>>;
+  spaceListFilter?: InputMaybe<Array<Scalars['UUID']>>;
   /** Spaces with which visibility this Innovation Hub will display. Only valid when type 'visibility' is used. */
   spaceVisibilityFilter?: InputMaybe<SpaceVisibility>;
 };
@@ -6687,6 +6619,15 @@ export type UpdateOrganizationSettingsPrivacyInput = {
   contributionRolesPubliclyVisible: Scalars['Boolean'];
 };
 
+export type UpdatePlatformSettingsInput = {
+  integration?: InputMaybe<UpdatePlatformSettingsIntegrationInput>;
+};
+
+export type UpdatePlatformSettingsIntegrationInput = {
+  /** Update the list of allowed URLs for iFrames within Markdown content. */
+  iframeAllowedUrls: Array<Scalars['String']>;
+};
+
 export type UpdatePostInput = {
   ID: Scalars['UUID'];
   /** A display identifier, unique within the containing scope. Note: updating the nameID will affect URL on the client. */
@@ -6725,16 +6666,18 @@ export type UpdateReferenceInput = {
   uri?: InputMaybe<Scalars['String']>;
 };
 
+export type UpdateSpaceAboutInput = {
+  /** The Profile of this Space. */
+  profile?: InputMaybe<UpdateProfileInput>;
+  when?: InputMaybe<Scalars['Markdown']>;
+  who?: InputMaybe<Scalars['Markdown']>;
+  why?: InputMaybe<Scalars['Markdown']>;
+};
+
 export type UpdateSpaceInput = {
   ID: Scalars['UUID'];
-  /** Update the contained Context entity. */
-  context?: InputMaybe<UpdateContextInput>;
-  /** The Profile of the InnovationFlow of this entity. */
-  innovationFlowData?: InputMaybe<UpdateInnovationFlowInput>;
-  /** A display identifier, unique within the containing scope. Note: updating the nameID will affect URL on the client. */
-  nameID?: InputMaybe<Scalars['NameID']>;
-  /** The Profile of this entity. */
-  profileData?: InputMaybe<UpdateProfileInput>;
+  /** Update the Space About information. */
+  about?: InputMaybe<UpdateSpaceAboutInput>;
 };
 
 export type UpdateSpacePlatformSettingsInput = {
@@ -6890,6 +6833,22 @@ export type UpdateVirtualContributorInput = {
   searchVisibility?: InputMaybe<SearchVisibility>;
 };
 
+export type UpdateVirtualContributorSettingsEntityInput = {
+  privacy?: InputMaybe<UpdateVirtualContributorSettingsPrivacyInput>;
+};
+
+export type UpdateVirtualContributorSettingsInput = {
+  /** Update the settings for the VirtualContributor. */
+  settings: UpdateVirtualContributorSettingsEntityInput;
+  /** The identifier for the VirtualCOntributor whose settings are to be updated. */
+  virtualContributorID: Scalars['UUID'];
+};
+
+export type UpdateVirtualContributorSettingsPrivacyInput = {
+  /** Enable the content of knowledge bases to be accessed or not. */
+  knowledgeBaseContentVisible: Scalars['Boolean'];
+};
+
 export type UpdateVisualInput = {
   alternativeText?: InputMaybe<Scalars['String']>;
   uri: Scalars['String'];
@@ -6904,6 +6863,85 @@ export type UpdateWhiteboardEntityInput = {
   /** The Profile of this entity. */
   profile?: InputMaybe<UpdateProfileInput>;
 };
+
+export type UrlResolverQueryResultCalendar = {
+  calendarEventId?: Maybe<Scalars['UUID']>;
+  id: Scalars['UUID'];
+};
+
+export type UrlResolverQueryResultCalloutsSet = {
+  calloutId?: Maybe<Scalars['UUID']>;
+  contributionId?: Maybe<Scalars['UUID']>;
+  id: Scalars['UUID'];
+  postId?: Maybe<Scalars['UUID']>;
+  type: UrlType;
+  whiteboardId?: Maybe<Scalars['UUID']>;
+};
+
+export type UrlResolverQueryResultCollaboration = {
+  calloutsSet: UrlResolverQueryResultCalloutsSet;
+  id: Scalars['UUID'];
+};
+
+export type UrlResolverQueryResultInnovationPack = {
+  id: Scalars['UUID'];
+  templatesSet: UrlResolverQueryResultTemplatesSet;
+};
+
+export type UrlResolverQueryResultSpace = {
+  calendar?: Maybe<UrlResolverQueryResultCalendar>;
+  collaboration: UrlResolverQueryResultCollaboration;
+  id: Scalars['UUID'];
+  level: SpaceLevel;
+  levelZeroSpaceID: Scalars['UUID'];
+  parentSpaces: Array<Scalars['UUID']>;
+  templatesSet?: Maybe<UrlResolverQueryResultTemplatesSet>;
+};
+
+export type UrlResolverQueryResultTemplatesSet = {
+  id: Scalars['UUID'];
+  templateId?: Maybe<Scalars['UUID']>;
+};
+
+export type UrlResolverQueryResultVirtualContributor = {
+  calloutsSet: UrlResolverQueryResultCalloutsSet;
+  id: Scalars['UUID'];
+};
+
+export type UrlResolverQueryResults = {
+  discussionId?: Maybe<Scalars['UUID']>;
+  innovationHubId?: Maybe<Scalars['UUID']>;
+  innovationPack?: Maybe<UrlResolverQueryResultInnovationPack>;
+  organizationId?: Maybe<Scalars['UUID']>;
+  space?: Maybe<UrlResolverQueryResultSpace>;
+  type: UrlType;
+  userId?: Maybe<Scalars['UUID']>;
+  virtualContributor?: Maybe<UrlResolverQueryResultVirtualContributor>;
+};
+
+export enum UrlType {
+  Admin = 'ADMIN',
+  Callout = 'CALLOUT',
+  CalloutsSet = 'CALLOUTS_SET',
+  ContributionPost = 'CONTRIBUTION_POST',
+  ContributionWhiteboard = 'CONTRIBUTION_WHITEBOARD',
+  ContributorsExplorer = 'CONTRIBUTORS_EXPLORER',
+  Discussion = 'DISCUSSION',
+  Documentation = 'DOCUMENTATION',
+  Flow = 'FLOW',
+  Forum = 'FORUM',
+  Home = 'HOME',
+  InnovationHub = 'INNOVATION_HUB',
+  InnovationLibrary = 'INNOVATION_LIBRARY',
+  InnovationPacks = 'INNOVATION_PACKS',
+  NotAuthorized = 'NOT_AUTHORIZED',
+  Organization = 'ORGANIZATION',
+  Space = 'SPACE',
+  SpaceExplorer = 'SPACE_EXPLORER',
+  Unknown = 'UNKNOWN',
+  User = 'USER',
+  VirtualContributor = 'VIRTUAL_CONTRIBUTOR',
+}
 
 export type User = Contributor & {
   /** The account hosted by this User. */
@@ -7015,6 +7053,11 @@ export type UserSettingsPrivacy = {
   contributionRolesPubliclyVisible: Scalars['Boolean'];
 };
 
+export type UsersInRolesResponse = {
+  role: RoleName;
+  users: Array<User>;
+};
+
 export type UsersWithAuthorizationCredentialInput = {
   /** The resource to which a credential needs to be bound. */
   resourceID?: InputMaybe<Scalars['UUID']>;
@@ -7083,10 +7126,22 @@ export type VirtualContributor = Contributor & {
   provider: Contributor;
   /** Visibility of the VC in searches. */
   searchVisibility: SearchVisibility;
+  /** The settings of this Virtual Contributor. */
+  settings: VirtualContributorSettings;
   /** The status of the virtual contributor */
   status: VirtualContributorStatus;
   /** The date at which the entity was last updated. */
   updatedDate?: Maybe<Scalars['DateTime']>;
+};
+
+export type VirtualContributorSettings = {
+  /** The privacy settings for this VirtualContributor */
+  privacy: VirtualContributorSettingsPrivacy;
+};
+
+export type VirtualContributorSettingsPrivacy = {
+  /** Are the contents of the knowledge base publicly visible. */
+  knowledgeBaseContentVisible: Scalars['Boolean'];
 };
 
 export enum VirtualContributorStatus {
@@ -7098,6 +7153,11 @@ export enum VirtualContributorStatus {
 export type VirtualContributorUpdatedSubscriptionResult = {
   /** The Virtual Contributor that was updated */
   virtualContributor: VirtualContributor;
+};
+
+export type VirtualContributorsInRolesResponse = {
+  role: RoleName;
+  virtualContributors: Array<VirtualContributor>;
 };
 
 export type Visual = {
@@ -7321,8 +7381,6 @@ export type ResolversTypes = {
   ActivityLogEntryOpportunityCreated: ResolverTypeWrapper<ActivityLogEntryOpportunityCreated>;
   ActivityLogEntryUpdateSent: ResolverTypeWrapper<ActivityLogEntryUpdateSent>;
   ActivityLogInput: ActivityLogInput;
-  Actor: ResolverTypeWrapper<Actor>;
-  ActorGroup: ResolverTypeWrapper<ActorGroup>;
   Agent: ResolverTypeWrapper<Agent>;
   AgentBeginVerifiedCredentialOfferOutput: ResolverTypeWrapper<AgentBeginVerifiedCredentialOfferOutput>;
   AgentBeginVerifiedCredentialRequestOutput: ResolverTypeWrapper<AgentBeginVerifiedCredentialRequestOutput>;
@@ -7333,15 +7391,13 @@ export type ResolversTypes = {
   AiPersonaEngine: AiPersonaEngine;
   AiPersonaInteractionMode: AiPersonaInteractionMode;
   AiPersonaService: ResolverTypeWrapper<AiPersonaService>;
-  AiPersonaServiceIngestInput: AiPersonaServiceIngestInput;
   AiServer: ResolverTypeWrapper<AiServer>;
   Application: ResolverTypeWrapper<Application>;
   ApplicationEventInput: ApplicationEventInput;
   ApplyForEntryRoleOnRoleSetInput: ApplyForEntryRoleOnRoleSetInput;
   AssignLicensePlanToAccount: AssignLicensePlanToAccount;
   AssignLicensePlanToSpace: AssignLicensePlanToSpace;
-  AssignOrganizationRoleToUserInput: AssignOrganizationRoleToUserInput;
-  AssignPlatformRoleToUserInput: AssignPlatformRoleToUserInput;
+  AssignPlatformRoleInput: AssignPlatformRoleInput;
   AssignRoleOnRoleSetToOrganizationInput: AssignRoleOnRoleSetToOrganizationInput;
   AssignRoleOnRoleSetToUserInput: AssignRoleOnRoleSetToUserInput;
   AssignRoleOnRoleSetToVirtualContributorInput: AssignRoleOnRoleSetToVirtualContributorInput;
@@ -7368,7 +7424,6 @@ export type ResolversTypes = {
   Callout: ResolverTypeWrapper<Callout>;
   CalloutContribution: ResolverTypeWrapper<CalloutContribution>;
   CalloutContributionDefaults: ResolverTypeWrapper<CalloutContributionDefaults>;
-  CalloutContributionFilterArgs: CalloutContributionFilterArgs;
   CalloutContributionPolicy: ResolverTypeWrapper<CalloutContributionPolicy>;
   CalloutContributionType: CalloutContributionType;
   CalloutFraming: ResolverTypeWrapper<CalloutFraming>;
@@ -7379,6 +7434,7 @@ export type ResolversTypes = {
   CalloutType: CalloutType;
   CalloutVisibility: CalloutVisibility;
   CalloutsSet: ResolverTypeWrapper<CalloutsSet>;
+  CalloutsSetType: CalloutsSetType;
   ChatGuidanceAnswerRelevanceInput: ChatGuidanceAnswerRelevanceInput;
   ChatGuidanceInput: ChatGuidanceInput;
   Collaboration: ResolverTypeWrapper<Collaboration>;
@@ -7398,18 +7454,14 @@ export type ResolversTypes = {
   Community: ResolverTypeWrapper<Community>;
   CommunityApplicationForRoleResult: ResolverTypeWrapper<CommunityApplicationForRoleResult>;
   CommunityApplicationResult: ResolverTypeWrapper<CommunityApplicationResult>;
-  CommunityContributorType: CommunityContributorType;
   CommunityGuidelines: ResolverTypeWrapper<CommunityGuidelines>;
   CommunityInvitationForRoleResult: ResolverTypeWrapper<CommunityInvitationForRoleResult>;
   CommunityInvitationResult: ResolverTypeWrapper<CommunityInvitationResult>;
   CommunityMembershipPolicy: CommunityMembershipPolicy;
   CommunityMembershipResult: ResolverTypeWrapper<CommunityMembershipResult>;
   CommunityMembershipStatus: CommunityMembershipStatus;
-  CommunityRoleImplicit: CommunityRoleImplicit;
-  CommunityRoleType: CommunityRoleType;
   Config: ResolverTypeWrapper<Config>;
   ContentUpdatePolicy: ContentUpdatePolicy;
-  Context: ResolverTypeWrapper<Context>;
   Contributor:
     | ResolversTypes['Organization']
     | ResolversTypes['User']
@@ -7417,10 +7469,9 @@ export type ResolversTypes = {
   ContributorFilterInput: ContributorFilterInput;
   ContributorRolePolicy: ResolverTypeWrapper<ContributorRolePolicy>;
   ContributorRoles: ResolverTypeWrapper<ContributorRoles>;
+  ConversionVcSpaceToVcKnowledgeBaseInput: ConversionVcSpaceToVcKnowledgeBaseInput;
   ConvertSubspaceToSpaceInput: ConvertSubspaceToSpaceInput;
   ConvertSubsubspaceToSubspaceInput: ConvertSubsubspaceToSubspaceInput;
-  CreateActorGroupInput: CreateActorGroupInput;
-  CreateActorInput: CreateActorInput;
   CreateAiPersonaInput: CreateAiPersonaInput;
   CreateAiPersonaServiceInput: CreateAiPersonaServiceInput;
   CreateCalendarEventOnCalendarInput: CreateCalendarEventOnCalendarInput;
@@ -7440,7 +7491,6 @@ export type ResolversTypes = {
   CreateCollaborationOnSpaceInput: CreateCollaborationOnSpaceInput;
   CreateCommunityGuidelinesData: ResolverTypeWrapper<CreateCommunityGuidelinesData>;
   CreateCommunityGuidelinesInput: CreateCommunityGuidelinesInput;
-  CreateContextInput: CreateContextInput;
   CreateContributionOnCalloutInput: CreateContributionOnCalloutInput;
   CreateInnovationFlowData: ResolverTypeWrapper<CreateInnovationFlowData>;
   CreateInnovationFlowInput: CreateInnovationFlowInput;
@@ -7455,13 +7505,13 @@ export type ResolversTypes = {
   CreateLocationInput: CreateLocationInput;
   CreateNVPInput: CreateNvpInput;
   CreateOrganizationInput: CreateOrganizationInput;
-  CreatePlatformInvitationForRoleInput: CreatePlatformInvitationForRoleInput;
   CreatePostInput: CreatePostInput;
   CreateProfileData: ResolverTypeWrapper<CreateProfileData>;
   CreateProfileInput: CreateProfileInput;
   CreateReferenceData: ResolverTypeWrapper<CreateReferenceData>;
   CreateReferenceInput: CreateReferenceInput;
   CreateReferenceOnProfileInput: CreateReferenceOnProfileInput;
+  CreateSpaceAboutInput: CreateSpaceAboutInput;
   CreateSpaceOnAccountInput: CreateSpaceOnAccountInput;
   CreateSubspaceInput: CreateSubspaceInput;
   CreateTagsetData: ResolverTypeWrapper<CreateTagsetData>;
@@ -7482,8 +7532,6 @@ export type ResolversTypes = {
   CredentialType: CredentialType;
   DID: ResolverTypeWrapper<Scalars['DID']>;
   DateTime: ResolverTypeWrapper<Scalars['DateTime']>;
-  DeleteActorGroupInput: DeleteActorGroupInput;
-  DeleteActorInput: DeleteActorInput;
   DeleteAiPersonaServiceInput: DeleteAiPersonaServiceInput;
   DeleteApplicationInput: DeleteApplicationInput;
   DeleteCalendarEventInput: DeleteCalendarEventInput;
@@ -7511,7 +7559,6 @@ export type ResolversTypes = {
   DiscussionsInput: DiscussionsInput;
   DiscussionsOrderBy: DiscussionsOrderBy;
   Document: ResolverTypeWrapper<Document>;
-  EcosystemModel: ResolverTypeWrapper<EcosystemModel>;
   Emoji: ResolverTypeWrapper<Scalars['Emoji']>;
   ExploreSpacesInput: ExploreSpacesInput;
   ExternalConfig: ExternalConfig;
@@ -7538,6 +7585,7 @@ export type ResolversTypes = {
   InAppNotificationState: InAppNotificationState;
   InAppNotificationUserMentioned: ResolverTypeWrapper<InAppNotificationUserMentioned>;
   InnovationFlow: ResolverTypeWrapper<InnovationFlow>;
+  InnovationFlowSettings: ResolverTypeWrapper<InnovationFlowSettings>;
   InnovationFlowState: ResolverTypeWrapper<InnovationFlowState>;
   InnovationHub: ResolverTypeWrapper<InnovationHub>;
   InnovationHubType: InnovationHubType;
@@ -7593,13 +7641,13 @@ export type ResolversTypes = {
   Organization: ResolverTypeWrapper<Organization>;
   OrganizationAuthorizationResetInput: OrganizationAuthorizationResetInput;
   OrganizationFilterInput: OrganizationFilterInput;
-  OrganizationRole: OrganizationRole;
   OrganizationSettings: ResolverTypeWrapper<OrganizationSettings>;
   OrganizationSettingsMembership: ResolverTypeWrapper<OrganizationSettingsMembership>;
   OrganizationSettingsPrivacy: ResolverTypeWrapper<OrganizationSettingsPrivacy>;
   OrganizationVerification: ResolverTypeWrapper<OrganizationVerification>;
   OrganizationVerificationEnum: OrganizationVerificationEnum;
   OrganizationVerificationEventInput: OrganizationVerificationEventInput;
+  OrganizationsInRolesResponse: ResolverTypeWrapper<OrganizationsInRolesResponse>;
   OryConfig: ResolverTypeWrapper<OryConfig>;
   PageInfo: ResolverTypeWrapper<PageInfo>;
   PaginatedOrganization: ResolverTypeWrapper<PaginatedOrganization>;
@@ -7608,9 +7656,10 @@ export type ResolversTypes = {
   Platform: ResolverTypeWrapper<Platform>;
   PlatformFeatureFlag: ResolverTypeWrapper<PlatformFeatureFlag>;
   PlatformFeatureFlagName: PlatformFeatureFlagName;
+  PlatformIntegrationSettings: ResolverTypeWrapper<PlatformIntegrationSettings>;
   PlatformInvitation: ResolverTypeWrapper<PlatformInvitation>;
   PlatformLocations: ResolverTypeWrapper<PlatformLocations>;
-  PlatformRole: PlatformRole;
+  PlatformSettings: ResolverTypeWrapper<PlatformSettings>;
   Post: ResolverTypeWrapper<Post>;
   Preference: ResolverTypeWrapper<Preference>;
   PreferenceDefinition: ResolverTypeWrapper<PreferenceDefinition>;
@@ -7628,8 +7677,7 @@ export type ResolversTypes = {
   RelayPaginatedSpaceEdge: ResolverTypeWrapper<RelayPaginatedSpaceEdge>;
   RelayPaginatedSpacePageInfo: ResolverTypeWrapper<RelayPaginatedSpacePageInfo>;
   RemoveCommunityGuidelinesContentInput: RemoveCommunityGuidelinesContentInput;
-  RemoveOrganizationRoleFromUserInput: RemoveOrganizationRoleFromUserInput;
-  RemovePlatformRoleFromUserInput: RemovePlatformRoleFromUserInput;
+  RemovePlatformRoleInput: RemovePlatformRoleInput;
   RemoveRoleOnRoleSetFromOrganizationInput: RemoveRoleOnRoleSetFromOrganizationInput;
   RemoveRoleOnRoleSetFromUserInput: RemoveRoleOnRoleSetFromUserInput;
   RemoveRoleOnRoleSetFromVirtualContributorInput: RemoveRoleOnRoleSetFromVirtualContributorInput;
@@ -7639,7 +7687,11 @@ export type ResolversTypes = {
   RevokeLicensePlanFromSpace: RevokeLicensePlanFromSpace;
   RevokeOrganizationAuthorizationCredentialInput: RevokeOrganizationAuthorizationCredentialInput;
   Role: ResolverTypeWrapper<Role>;
+  RoleName: RoleName;
   RoleSet: ResolverTypeWrapper<RoleSet>;
+  RoleSetContributorType: RoleSetContributorType;
+  RoleSetRoleImplicit: RoleSetRoleImplicit;
+  RoleSetType: RoleSetType;
   RolesOrganizationInput: RolesOrganizationInput;
   RolesResult: ResolverTypeWrapper<RolesResult>;
   RolesResultCommunity: ResolverTypeWrapper<RolesResultCommunity>;
@@ -7675,6 +7727,7 @@ export type ResolversTypes = {
   Sentry: ResolverTypeWrapper<Sentry>;
   ServiceMetadata: ResolverTypeWrapper<ServiceMetadata>;
   Space: ResolverTypeWrapper<Space>;
+  SpaceAbout: ResolverTypeWrapper<SpaceAbout>;
   SpaceFilterInput: SpaceFilterInput;
   SpaceLevel: SpaceLevel;
   SpacePendingMembershipInfo: ResolverTypeWrapper<SpacePendingMembershipInfo>;
@@ -7717,10 +7770,8 @@ export type ResolversTypes = {
   TransferAccountInnovationPackInput: TransferAccountInnovationPackInput;
   TransferAccountSpaceInput: TransferAccountSpaceInput;
   TransferAccountVirtualContributorInput: TransferAccountVirtualContributorInput;
+  TransferCalloutInput: TransferCalloutInput;
   UUID: ResolverTypeWrapper<Scalars['UUID']>;
-  UUID_NAMEID: ResolverTypeWrapper<Scalars['UUID_NAMEID']>;
-  UUID_NAMEID_EMAIL: ResolverTypeWrapper<Scalars['UUID_NAMEID_EMAIL']>;
-  UpdateActorInput: UpdateActorInput;
   UpdateAiPersonaInput: UpdateAiPersonaInput;
   UpdateAiPersonaServiceInput: UpdateAiPersonaServiceInput;
   UpdateApplicationFormOnRoleSetInput: UpdateApplicationFormOnRoleSetInput;
@@ -7734,15 +7785,12 @@ export type ResolversTypes = {
   UpdateCalloutsSortOrderInput: UpdateCalloutsSortOrderInput;
   UpdateCollaborationFromTemplateInput: UpdateCollaborationFromTemplateInput;
   UpdateCommunityGuidelinesEntityInput: UpdateCommunityGuidelinesEntityInput;
-  UpdateContextInput: UpdateContextInput;
   UpdateContributionCalloutsSortOrderInput: UpdateContributionCalloutsSortOrderInput;
   UpdateDiscussionInput: UpdateDiscussionInput;
   UpdateDocumentInput: UpdateDocumentInput;
-  UpdateEcosystemModelInput: UpdateEcosystemModelInput;
   UpdateFormInput: UpdateFormInput;
   UpdateFormQuestionInput: UpdateFormQuestionInput;
   UpdateInnovationFlowEntityInput: UpdateInnovationFlowEntityInput;
-  UpdateInnovationFlowInput: UpdateInnovationFlowInput;
   UpdateInnovationFlowSelectedStateInput: UpdateInnovationFlowSelectedStateInput;
   UpdateInnovationFlowSingleStateInput: UpdateInnovationFlowSingleStateInput;
   UpdateInnovationFlowStateInput: UpdateInnovationFlowStateInput;
@@ -7759,10 +7807,13 @@ export type ResolversTypes = {
   UpdateOrganizationSettingsInput: UpdateOrganizationSettingsInput;
   UpdateOrganizationSettingsMembershipInput: UpdateOrganizationSettingsMembershipInput;
   UpdateOrganizationSettingsPrivacyInput: UpdateOrganizationSettingsPrivacyInput;
+  UpdatePlatformSettingsInput: UpdatePlatformSettingsInput;
+  UpdatePlatformSettingsIntegrationInput: UpdatePlatformSettingsIntegrationInput;
   UpdatePostInput: UpdatePostInput;
   UpdateProfileDirectInput: UpdateProfileDirectInput;
   UpdateProfileInput: UpdateProfileInput;
   UpdateReferenceInput: UpdateReferenceInput;
+  UpdateSpaceAboutInput: UpdateSpaceAboutInput;
   UpdateSpaceInput: UpdateSpaceInput;
   UpdateSpacePlatformSettingsInput: UpdateSpacePlatformSettingsInput;
   UpdateSpaceSettingsCollaborationInput: UpdateSpaceSettingsCollaborationInput;
@@ -7783,9 +7834,21 @@ export type ResolversTypes = {
   UpdateUserSettingsInput: UpdateUserSettingsInput;
   UpdateUserSettingsPrivacyInput: UpdateUserSettingsPrivacyInput;
   UpdateVirtualContributorInput: UpdateVirtualContributorInput;
+  UpdateVirtualContributorSettingsEntityInput: UpdateVirtualContributorSettingsEntityInput;
+  UpdateVirtualContributorSettingsInput: UpdateVirtualContributorSettingsInput;
+  UpdateVirtualContributorSettingsPrivacyInput: UpdateVirtualContributorSettingsPrivacyInput;
   UpdateVisualInput: UpdateVisualInput;
   UpdateWhiteboardEntityInput: UpdateWhiteboardEntityInput;
   Upload: ResolverTypeWrapper<Scalars['Upload']>;
+  UrlResolverQueryResultCalendar: ResolverTypeWrapper<UrlResolverQueryResultCalendar>;
+  UrlResolverQueryResultCalloutsSet: ResolverTypeWrapper<UrlResolverQueryResultCalloutsSet>;
+  UrlResolverQueryResultCollaboration: ResolverTypeWrapper<UrlResolverQueryResultCollaboration>;
+  UrlResolverQueryResultInnovationPack: ResolverTypeWrapper<UrlResolverQueryResultInnovationPack>;
+  UrlResolverQueryResultSpace: ResolverTypeWrapper<UrlResolverQueryResultSpace>;
+  UrlResolverQueryResultTemplatesSet: ResolverTypeWrapper<UrlResolverQueryResultTemplatesSet>;
+  UrlResolverQueryResultVirtualContributor: ResolverTypeWrapper<UrlResolverQueryResultVirtualContributor>;
+  UrlResolverQueryResults: ResolverTypeWrapper<UrlResolverQueryResults>;
+  UrlType: UrlType;
   User: ResolverTypeWrapper<User>;
   UserAuthenticationResult: ResolverTypeWrapper<UserAuthenticationResult>;
   UserAuthorizationPrivilegesInput: UserAuthorizationPrivilegesInput;
@@ -7796,13 +7859,17 @@ export type ResolversTypes = {
   UserSettings: ResolverTypeWrapper<UserSettings>;
   UserSettingsCommunication: ResolverTypeWrapper<UserSettingsCommunication>;
   UserSettingsPrivacy: ResolverTypeWrapper<UserSettingsPrivacy>;
+  UsersInRolesResponse: ResolverTypeWrapper<UsersInRolesResponse>;
   UsersWithAuthorizationCredentialInput: UsersWithAuthorizationCredentialInput;
   VcInteraction: ResolverTypeWrapper<VcInteraction>;
   VerifiedCredential: ResolverTypeWrapper<VerifiedCredential>;
   VerifiedCredentialClaim: ResolverTypeWrapper<VerifiedCredentialClaim>;
   VirtualContributor: ResolverTypeWrapper<VirtualContributor>;
+  VirtualContributorSettings: ResolverTypeWrapper<VirtualContributorSettings>;
+  VirtualContributorSettingsPrivacy: ResolverTypeWrapper<VirtualContributorSettingsPrivacy>;
   VirtualContributorStatus: VirtualContributorStatus;
   VirtualContributorUpdatedSubscriptionResult: ResolverTypeWrapper<VirtualContributorUpdatedSubscriptionResult>;
+  VirtualContributorsInRolesResponse: ResolverTypeWrapper<VirtualContributorsInRolesResponse>;
   Visual: ResolverTypeWrapper<Visual>;
   VisualConstraints: ResolverTypeWrapper<VisualConstraints>;
   VisualType: VisualType;
@@ -7849,22 +7916,18 @@ export type ResolversParentTypes = {
   ActivityLogEntryOpportunityCreated: ActivityLogEntryOpportunityCreated;
   ActivityLogEntryUpdateSent: ActivityLogEntryUpdateSent;
   ActivityLogInput: ActivityLogInput;
-  Actor: Actor;
-  ActorGroup: ActorGroup;
   Agent: Agent;
   AgentBeginVerifiedCredentialOfferOutput: AgentBeginVerifiedCredentialOfferOutput;
   AgentBeginVerifiedCredentialRequestOutput: AgentBeginVerifiedCredentialRequestOutput;
   AiPersona: AiPersona;
   AiPersonaService: AiPersonaService;
-  AiPersonaServiceIngestInput: AiPersonaServiceIngestInput;
   AiServer: AiServer;
   Application: Application;
   ApplicationEventInput: ApplicationEventInput;
   ApplyForEntryRoleOnRoleSetInput: ApplyForEntryRoleOnRoleSetInput;
   AssignLicensePlanToAccount: AssignLicensePlanToAccount;
   AssignLicensePlanToSpace: AssignLicensePlanToSpace;
-  AssignOrganizationRoleToUserInput: AssignOrganizationRoleToUserInput;
-  AssignPlatformRoleToUserInput: AssignPlatformRoleToUserInput;
+  AssignPlatformRoleInput: AssignPlatformRoleInput;
   AssignRoleOnRoleSetToOrganizationInput: AssignRoleOnRoleSetToOrganizationInput;
   AssignRoleOnRoleSetToUserInput: AssignRoleOnRoleSetToUserInput;
   AssignRoleOnRoleSetToVirtualContributorInput: AssignRoleOnRoleSetToVirtualContributorInput;
@@ -7884,7 +7947,6 @@ export type ResolversParentTypes = {
   Callout: Callout;
   CalloutContribution: CalloutContribution;
   CalloutContributionDefaults: CalloutContributionDefaults;
-  CalloutContributionFilterArgs: CalloutContributionFilterArgs;
   CalloutContributionPolicy: CalloutContributionPolicy;
   CalloutFraming: CalloutFraming;
   CalloutGroup: CalloutGroup;
@@ -7914,7 +7976,6 @@ export type ResolversParentTypes = {
   CommunityInvitationResult: CommunityInvitationResult;
   CommunityMembershipResult: CommunityMembershipResult;
   Config: Config;
-  Context: Context;
   Contributor:
     | ResolversParentTypes['Organization']
     | ResolversParentTypes['User']
@@ -7922,10 +7983,9 @@ export type ResolversParentTypes = {
   ContributorFilterInput: ContributorFilterInput;
   ContributorRolePolicy: ContributorRolePolicy;
   ContributorRoles: ContributorRoles;
+  ConversionVcSpaceToVcKnowledgeBaseInput: ConversionVcSpaceToVcKnowledgeBaseInput;
   ConvertSubspaceToSpaceInput: ConvertSubspaceToSpaceInput;
   ConvertSubsubspaceToSubspaceInput: ConvertSubsubspaceToSubspaceInput;
-  CreateActorGroupInput: CreateActorGroupInput;
-  CreateActorInput: CreateActorInput;
   CreateAiPersonaInput: CreateAiPersonaInput;
   CreateAiPersonaServiceInput: CreateAiPersonaServiceInput;
   CreateCalendarEventOnCalendarInput: CreateCalendarEventOnCalendarInput;
@@ -7945,7 +8005,6 @@ export type ResolversParentTypes = {
   CreateCollaborationOnSpaceInput: CreateCollaborationOnSpaceInput;
   CreateCommunityGuidelinesData: CreateCommunityGuidelinesData;
   CreateCommunityGuidelinesInput: CreateCommunityGuidelinesInput;
-  CreateContextInput: CreateContextInput;
   CreateContributionOnCalloutInput: CreateContributionOnCalloutInput;
   CreateInnovationFlowData: CreateInnovationFlowData;
   CreateInnovationFlowInput: CreateInnovationFlowInput;
@@ -7960,13 +8019,13 @@ export type ResolversParentTypes = {
   CreateLocationInput: CreateLocationInput;
   CreateNVPInput: CreateNvpInput;
   CreateOrganizationInput: CreateOrganizationInput;
-  CreatePlatformInvitationForRoleInput: CreatePlatformInvitationForRoleInput;
   CreatePostInput: CreatePostInput;
   CreateProfileData: CreateProfileData;
   CreateProfileInput: CreateProfileInput;
   CreateReferenceData: CreateReferenceData;
   CreateReferenceInput: CreateReferenceInput;
   CreateReferenceOnProfileInput: CreateReferenceOnProfileInput;
+  CreateSpaceAboutInput: CreateSpaceAboutInput;
   CreateSpaceOnAccountInput: CreateSpaceOnAccountInput;
   CreateSubspaceInput: CreateSubspaceInput;
   CreateTagsetData: CreateTagsetData;
@@ -7986,8 +8045,6 @@ export type ResolversParentTypes = {
   CredentialMetadataOutput: CredentialMetadataOutput;
   DID: Scalars['DID'];
   DateTime: Scalars['DateTime'];
-  DeleteActorGroupInput: DeleteActorGroupInput;
-  DeleteActorInput: DeleteActorInput;
   DeleteAiPersonaServiceInput: DeleteAiPersonaServiceInput;
   DeleteApplicationInput: DeleteApplicationInput;
   DeleteCalendarEventInput: DeleteCalendarEventInput;
@@ -8014,7 +8071,6 @@ export type ResolversParentTypes = {
   Discussion: Discussion;
   DiscussionsInput: DiscussionsInput;
   Document: Document;
-  EcosystemModel: EcosystemModel;
   Emoji: Scalars['Emoji'];
   ExploreSpacesInput: ExploreSpacesInput;
   ExternalConfig: ExternalConfig;
@@ -8039,6 +8095,7 @@ export type ResolversParentTypes = {
   InAppNotificationCommunityNewMember: InAppNotificationCommunityNewMember;
   InAppNotificationUserMentioned: InAppNotificationUserMentioned;
   InnovationFlow: InnovationFlow;
+  InnovationFlowSettings: InnovationFlowSettings;
   InnovationFlowState: InnovationFlowState;
   InnovationHub: InnovationHub;
   InnovationPack: InnovationPack;
@@ -8089,6 +8146,7 @@ export type ResolversParentTypes = {
   OrganizationSettingsPrivacy: OrganizationSettingsPrivacy;
   OrganizationVerification: OrganizationVerification;
   OrganizationVerificationEventInput: OrganizationVerificationEventInput;
+  OrganizationsInRolesResponse: OrganizationsInRolesResponse;
   OryConfig: OryConfig;
   PageInfo: PageInfo;
   PaginatedOrganization: PaginatedOrganization;
@@ -8096,8 +8154,10 @@ export type ResolversParentTypes = {
   PaginatedUsers: PaginatedUsers;
   Platform: Platform;
   PlatformFeatureFlag: PlatformFeatureFlag;
+  PlatformIntegrationSettings: PlatformIntegrationSettings;
   PlatformInvitation: PlatformInvitation;
   PlatformLocations: PlatformLocations;
+  PlatformSettings: PlatformSettings;
   Post: Post;
   Preference: Preference;
   PreferenceDefinition: PreferenceDefinition;
@@ -8112,8 +8172,7 @@ export type ResolversParentTypes = {
   RelayPaginatedSpaceEdge: RelayPaginatedSpaceEdge;
   RelayPaginatedSpacePageInfo: RelayPaginatedSpacePageInfo;
   RemoveCommunityGuidelinesContentInput: RemoveCommunityGuidelinesContentInput;
-  RemoveOrganizationRoleFromUserInput: RemoveOrganizationRoleFromUserInput;
-  RemovePlatformRoleFromUserInput: RemovePlatformRoleFromUserInput;
+  RemovePlatformRoleInput: RemovePlatformRoleInput;
   RemoveRoleOnRoleSetFromOrganizationInput: RemoveRoleOnRoleSetFromOrganizationInput;
   RemoveRoleOnRoleSetFromUserInput: RemoveRoleOnRoleSetFromUserInput;
   RemoveRoleOnRoleSetFromVirtualContributorInput: RemoveRoleOnRoleSetFromVirtualContributorInput;
@@ -8157,6 +8216,7 @@ export type ResolversParentTypes = {
   Sentry: Sentry;
   ServiceMetadata: ServiceMetadata;
   Space: Space;
+  SpaceAbout: SpaceAbout;
   SpaceFilterInput: SpaceFilterInput;
   SpacePendingMembershipInfo: SpacePendingMembershipInfo;
   SpaceSettings: SpaceSettings;
@@ -8189,10 +8249,8 @@ export type ResolversParentTypes = {
   TransferAccountInnovationPackInput: TransferAccountInnovationPackInput;
   TransferAccountSpaceInput: TransferAccountSpaceInput;
   TransferAccountVirtualContributorInput: TransferAccountVirtualContributorInput;
+  TransferCalloutInput: TransferCalloutInput;
   UUID: Scalars['UUID'];
-  UUID_NAMEID: Scalars['UUID_NAMEID'];
-  UUID_NAMEID_EMAIL: Scalars['UUID_NAMEID_EMAIL'];
-  UpdateActorInput: UpdateActorInput;
   UpdateAiPersonaInput: UpdateAiPersonaInput;
   UpdateAiPersonaServiceInput: UpdateAiPersonaServiceInput;
   UpdateApplicationFormOnRoleSetInput: UpdateApplicationFormOnRoleSetInput;
@@ -8206,15 +8264,12 @@ export type ResolversParentTypes = {
   UpdateCalloutsSortOrderInput: UpdateCalloutsSortOrderInput;
   UpdateCollaborationFromTemplateInput: UpdateCollaborationFromTemplateInput;
   UpdateCommunityGuidelinesEntityInput: UpdateCommunityGuidelinesEntityInput;
-  UpdateContextInput: UpdateContextInput;
   UpdateContributionCalloutsSortOrderInput: UpdateContributionCalloutsSortOrderInput;
   UpdateDiscussionInput: UpdateDiscussionInput;
   UpdateDocumentInput: UpdateDocumentInput;
-  UpdateEcosystemModelInput: UpdateEcosystemModelInput;
   UpdateFormInput: UpdateFormInput;
   UpdateFormQuestionInput: UpdateFormQuestionInput;
   UpdateInnovationFlowEntityInput: UpdateInnovationFlowEntityInput;
-  UpdateInnovationFlowInput: UpdateInnovationFlowInput;
   UpdateInnovationFlowSelectedStateInput: UpdateInnovationFlowSelectedStateInput;
   UpdateInnovationFlowSingleStateInput: UpdateInnovationFlowSingleStateInput;
   UpdateInnovationFlowStateInput: UpdateInnovationFlowStateInput;
@@ -8231,10 +8286,13 @@ export type ResolversParentTypes = {
   UpdateOrganizationSettingsInput: UpdateOrganizationSettingsInput;
   UpdateOrganizationSettingsMembershipInput: UpdateOrganizationSettingsMembershipInput;
   UpdateOrganizationSettingsPrivacyInput: UpdateOrganizationSettingsPrivacyInput;
+  UpdatePlatformSettingsInput: UpdatePlatformSettingsInput;
+  UpdatePlatformSettingsIntegrationInput: UpdatePlatformSettingsIntegrationInput;
   UpdatePostInput: UpdatePostInput;
   UpdateProfileDirectInput: UpdateProfileDirectInput;
   UpdateProfileInput: UpdateProfileInput;
   UpdateReferenceInput: UpdateReferenceInput;
+  UpdateSpaceAboutInput: UpdateSpaceAboutInput;
   UpdateSpaceInput: UpdateSpaceInput;
   UpdateSpacePlatformSettingsInput: UpdateSpacePlatformSettingsInput;
   UpdateSpaceSettingsCollaborationInput: UpdateSpaceSettingsCollaborationInput;
@@ -8255,9 +8313,20 @@ export type ResolversParentTypes = {
   UpdateUserSettingsInput: UpdateUserSettingsInput;
   UpdateUserSettingsPrivacyInput: UpdateUserSettingsPrivacyInput;
   UpdateVirtualContributorInput: UpdateVirtualContributorInput;
+  UpdateVirtualContributorSettingsEntityInput: UpdateVirtualContributorSettingsEntityInput;
+  UpdateVirtualContributorSettingsInput: UpdateVirtualContributorSettingsInput;
+  UpdateVirtualContributorSettingsPrivacyInput: UpdateVirtualContributorSettingsPrivacyInput;
   UpdateVisualInput: UpdateVisualInput;
   UpdateWhiteboardEntityInput: UpdateWhiteboardEntityInput;
   Upload: Scalars['Upload'];
+  UrlResolverQueryResultCalendar: UrlResolverQueryResultCalendar;
+  UrlResolverQueryResultCalloutsSet: UrlResolverQueryResultCalloutsSet;
+  UrlResolverQueryResultCollaboration: UrlResolverQueryResultCollaboration;
+  UrlResolverQueryResultInnovationPack: UrlResolverQueryResultInnovationPack;
+  UrlResolverQueryResultSpace: UrlResolverQueryResultSpace;
+  UrlResolverQueryResultTemplatesSet: UrlResolverQueryResultTemplatesSet;
+  UrlResolverQueryResultVirtualContributor: UrlResolverQueryResultVirtualContributor;
+  UrlResolverQueryResults: UrlResolverQueryResults;
   User: User;
   UserAuthenticationResult: UserAuthenticationResult;
   UserAuthorizationPrivilegesInput: UserAuthorizationPrivilegesInput;
@@ -8268,12 +8337,16 @@ export type ResolversParentTypes = {
   UserSettings: UserSettings;
   UserSettingsCommunication: UserSettingsCommunication;
   UserSettingsPrivacy: UserSettingsPrivacy;
+  UsersInRolesResponse: UsersInRolesResponse;
   UsersWithAuthorizationCredentialInput: UsersWithAuthorizationCredentialInput;
   VcInteraction: VcInteraction;
   VerifiedCredential: VerifiedCredential;
   VerifiedCredentialClaim: VerifiedCredentialClaim;
   VirtualContributor: VirtualContributor;
+  VirtualContributorSettings: VirtualContributorSettings;
+  VirtualContributorSettingsPrivacy: VirtualContributorSettingsPrivacy;
   VirtualContributorUpdatedSubscriptionResult: VirtualContributorUpdatedSubscriptionResult;
+  VirtualContributorsInRolesResponse: VirtualContributorsInRolesResponse;
   Visual: Visual;
   VisualConstraints: VisualConstraints;
   VisualUploadImageInput: VisualUploadImageInput;
@@ -8665,7 +8738,7 @@ export type ActivityLogEntryMemberJoinedResolvers<
     ContextType
   >;
   contributorType?: Resolver<
-    ResolversTypes['CommunityContributorType'],
+    ResolversTypes['RoleSetContributorType'],
     ParentType,
     ContextType
   >;
@@ -8727,71 +8800,6 @@ export type ActivityLogEntryUpdateSentResolvers<
   triggeredBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   type?: Resolver<ResolversTypes['ActivityEventType'], ParentType, ContextType>;
   updates?: Resolver<ResolversTypes['Room'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ActorResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Actor'] = ResolversParentTypes['Actor']
-> = {
-  authorization?: Resolver<
-    Maybe<ResolversTypes['Authorization']>,
-    ParentType,
-    ContextType
-  >;
-  createdDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
-  description?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  impact?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  updatedDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
-  value?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ActorGroupResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['ActorGroup'] = ResolversParentTypes['ActorGroup']
-> = {
-  actors?: Resolver<
-    Maybe<Array<ResolversTypes['Actor']>>,
-    ParentType,
-    ContextType
-  >;
-  authorization?: Resolver<
-    Maybe<ResolversTypes['Authorization']>,
-    ParentType,
-    ContextType
-  >;
-  createdDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
-  description?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  updatedDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -8887,6 +8895,7 @@ export type AiPersonaResolvers<
     ParentType,
     ContextType
   >;
+  engine?: Resolver<ResolversTypes['AiPersonaEngine'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   interactionModes?: Resolver<
     Array<ResolversTypes['AiPersonaInteractionMode']>,
@@ -9463,11 +9472,7 @@ export type CalloutsSetResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<
-    Array<ResolversTypes['CalloutGroup']>,
-    ParentType,
-    ContextType
-  >;
+  type?: Resolver<ResolversTypes['CalloutsSetType'], ParentType, ContextType>;
   updatedDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -9717,7 +9722,7 @@ export type CommunityInvitationForRoleResultResolvers<
   communityID?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   contributorID?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   contributorType?: Resolver<
-    ResolversTypes['CommunityContributorType'],
+    ResolversTypes['RoleSetContributorType'],
     ParentType,
     ContextType
   >;
@@ -9794,32 +9799,6 @@ export type ConfigResolvers<
   >;
   sentry?: Resolver<ResolversTypes['Sentry'], ParentType, ContextType>;
   storage?: Resolver<ResolversTypes['StorageConfig'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ContextResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['Context'] = ResolversParentTypes['Context']
-> = {
-  authorization?: Resolver<
-    Maybe<ResolversTypes['Authorization']>,
-    ParentType,
-    ContextType
-  >;
-  createdDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
-  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  impact?: Resolver<Maybe<ResolversTypes['Markdown']>, ParentType, ContextType>;
-  updatedDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
-  vision?: Resolver<Maybe<ResolversTypes['Markdown']>, ParentType, ContextType>;
-  who?: Resolver<Maybe<ResolversTypes['Markdown']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -10099,6 +10078,11 @@ export type CreateProfileDataResolvers<
     ContextType
   >;
   tagline?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  tags?: Resolver<
+    Maybe<Array<ResolversTypes['String']>>,
+    ParentType,
+    ContextType
+  >;
   tagsets?: Resolver<
     Maybe<Array<ResolversTypes['CreateTagsetData']>>,
     ParentType,
@@ -10310,39 +10294,6 @@ export type DocumentResolvers<
   >;
   uploadedDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   url?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type EcosystemModelResolvers<
-  ContextType = any,
-  ParentType extends ResolversParentTypes['EcosystemModel'] = ResolversParentTypes['EcosystemModel']
-> = {
-  actorGroups?: Resolver<
-    Maybe<Array<ResolversTypes['ActorGroup']>>,
-    ParentType,
-    ContextType
-  >;
-  authorization?: Resolver<
-    Maybe<ResolversTypes['Authorization']>,
-    ParentType,
-    ContextType
-  >;
-  createdDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
-  description?: Resolver<
-    Maybe<ResolversTypes['String']>,
-    ParentType,
-    ContextType
-  >;
-  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
-  updatedDate?: Resolver<
-    Maybe<ResolversTypes['DateTime']>,
-    ParentType,
-    ContextType
-  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -10598,7 +10549,7 @@ export type InAppNotificationCommunityNewMemberResolvers<
     ContextType
   >;
   contributorType?: Resolver<
-    ResolversTypes['CommunityContributorType'],
+    ResolversTypes['RoleSetContributorType'],
     ParentType,
     ContextType
   >;
@@ -10641,7 +10592,7 @@ export type InAppNotificationUserMentionedResolvers<
   >;
   commentUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   contributorType?: Resolver<
-    ResolversTypes['CommunityContributorType'],
+    ResolversTypes['RoleSetContributorType'],
     ParentType,
     ContextType
   >;
@@ -10687,6 +10638,11 @@ export type InnovationFlowResolvers<
   >;
   id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
+  settings?: Resolver<
+    ResolversTypes['InnovationFlowSettings'],
+    ParentType,
+    ContextType
+  >;
   states?: Resolver<
     Array<ResolversTypes['InnovationFlowState']>,
     ParentType,
@@ -10694,6 +10650,23 @@ export type InnovationFlowResolvers<
   >;
   updatedDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type InnovationFlowSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['InnovationFlowSettings'] = ResolversParentTypes['InnovationFlowSettings']
+> = {
+  maximumNumberOfStates?: Resolver<
+    ResolversTypes['Float'],
+    ParentType,
+    ContextType
+  >;
+  minimumNumberOfStates?: Resolver<
+    ResolversTypes['Float'],
     ParentType,
     ContextType
   >;
@@ -10843,14 +10816,14 @@ export type InvitationResolvers<
     ContextType
   >;
   contributorType?: Resolver<
-    ResolversTypes['CommunityContributorType'],
+    ResolversTypes['RoleSetContributorType'],
     ParentType,
     ContextType
   >;
   createdBy?: Resolver<ResolversTypes['User'], ParentType, ContextType>;
   createdDate?: Resolver<ResolversTypes['DateTime'], ParentType, ContextType>;
   extraRole?: Resolver<
-    Maybe<ResolversTypes['CommunityRoleType']>,
+    Maybe<ResolversTypes['RoleName']>,
     ParentType,
     ContextType
   >;
@@ -11273,20 +11246,50 @@ export type LookupByNameQueryResultsResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['LookupByNameQueryResults'] = ResolversParentTypes['LookupByNameQueryResults']
 > = {
+  innovationHub?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupByNameQueryResultsInnovationHubArgs, 'NAMEID'>
+  >;
   innovationPack?: Resolver<
-    Maybe<ResolversTypes['InnovationPack']>,
+    Maybe<ResolversTypes['String']>,
     ParentType,
     ContextType,
     RequireFields<LookupByNameQueryResultsInnovationPackArgs, 'NAMEID'>
   >;
+  organization?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupByNameQueryResultsOrganizationArgs, 'NAMEID'>
+  >;
+  space?: Resolver<
+    Maybe<ResolversTypes['Space']>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupByNameQueryResultsSpaceArgs, 'NAMEID'>
+  >;
   template?: Resolver<
-    Maybe<ResolversTypes['Template']>,
+    Maybe<ResolversTypes['String']>,
     ParentType,
     ContextType,
     RequireFields<
       LookupByNameQueryResultsTemplateArgs,
       'NAMEID' | 'templatesSetID'
     >
+  >;
+  user?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupByNameQueryResultsUserArgs, 'NAMEID'>
+  >;
+  virtualContributor?: Resolver<
+    Maybe<ResolversTypes['String']>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupByNameQueryResultsVirtualContributorArgs, 'NAMEID'>
   >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -11342,12 +11345,6 @@ export type LookupMyPrivilegesQueryResultsResolvers<
     ParentType,
     ContextType,
     RequireFields<LookupMyPrivilegesQueryResultsCommunityGuidelinesArgs, 'ID'>
-  >;
-  context?: Resolver<
-    Maybe<Array<ResolversTypes['AuthorizationPrivilege']>>,
-    ParentType,
-    ContextType,
-    RequireFields<LookupMyPrivilegesQueryResultsContextArgs, 'ID'>
   >;
   document?: Resolver<
     Maybe<Array<ResolversTypes['AuthorizationPrivilege']>>,
@@ -11415,6 +11412,12 @@ export type LookupMyPrivilegesQueryResultsResolvers<
     ContextType,
     RequireFields<LookupMyPrivilegesQueryResultsSpaceArgs, 'ID'>
   >;
+  spaceAbout?: Resolver<
+    Maybe<Array<ResolversTypes['AuthorizationPrivilege']>>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupMyPrivilegesQueryResultsSpaceAboutArgs, 'ID'>
+  >;
   storageAggregator?: Resolver<
     Maybe<Array<ResolversTypes['AuthorizationPrivilege']>>,
     ParentType,
@@ -11470,6 +11473,12 @@ export type LookupQueryResultsResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['LookupQueryResults'] = ResolversParentTypes['LookupQueryResults']
 > = {
+  about?: Resolver<
+    Maybe<ResolversTypes['SpaceAbout']>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupQueryResultsAboutArgs, 'ID'>
+  >;
   account?: Resolver<
     Maybe<ResolversTypes['Account']>,
     ParentType,
@@ -11539,12 +11548,6 @@ export type LookupQueryResultsResolvers<
     ContextType,
     RequireFields<LookupQueryResultsCommunityGuidelinesArgs, 'ID'>
   >;
-  context?: Resolver<
-    Maybe<ResolversTypes['Context']>,
-    ParentType,
-    ContextType,
-    RequireFields<LookupQueryResultsContextArgs, 'ID'>
-  >;
   document?: Resolver<
     Maybe<ResolversTypes['Document']>,
     ParentType,
@@ -11591,6 +11594,12 @@ export type LookupQueryResultsResolvers<
     Maybe<ResolversTypes['LookupMyPrivilegesQueryResults']>,
     ParentType,
     ContextType
+  >;
+  organization?: Resolver<
+    Maybe<ResolversTypes['Organization']>,
+    ParentType,
+    ContextType,
+    RequireFields<LookupQueryResultsOrganizationArgs, 'ID'>
   >;
   post?: Resolver<
     Maybe<ResolversTypes['Post']>,
@@ -11694,6 +11703,12 @@ export type MeQueryResultsResolvers<
     ContextType,
     Partial<MeQueryResultsCommunityInvitationsArgs>
   >;
+  communityInvitationsCount?: Resolver<
+    ResolversTypes['Float'],
+    ParentType,
+    ContextType,
+    Partial<MeQueryResultsCommunityInvitationsCountArgs>
+  >;
   id?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   mySpaces?: Resolver<
     Array<ResolversTypes['MySpaceResults']>,
@@ -11709,7 +11724,8 @@ export type MeQueryResultsResolvers<
   spaceMembershipsHierarchical?: Resolver<
     Array<ResolversTypes['CommunityMembershipResult']>,
     ParentType,
-    ContextType
+    ContextType,
+    Partial<MeQueryResultsSpaceMembershipsHierarchicalArgs>
   >;
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
@@ -11860,12 +11876,6 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationAiServerDeleteAiPersonaServiceArgs, 'deleteData'>
   >;
-  aiServerPersonaServiceIngest?: Resolver<
-    ResolversTypes['Boolean'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationAiServerPersonaServiceIngestArgs, 'ingestData'>
-  >;
   aiServerUpdateAiPersonaService?: Resolver<
     ResolversTypes['AiPersonaService'],
     ParentType,
@@ -11899,17 +11909,11 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationAssignLicensePlanToSpaceArgs, 'planData'>
   >;
-  assignOrganizationRoleToUser?: Resolver<
-    ResolversTypes['User'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationAssignOrganizationRoleToUserArgs, 'membershipData'>
-  >;
   assignPlatformRoleToUser?: Resolver<
     ResolversTypes['User'],
     ParentType,
     ContextType,
-    RequireFields<MutationAssignPlatformRoleToUserArgs, 'membershipData'>
+    RequireFields<MutationAssignPlatformRoleToUserArgs, 'roleData'>
   >;
   assignRoleToOrganization?: Resolver<
     ResolversTypes['Organization'],
@@ -12021,23 +12025,14 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationConvertOpportunityToChallengeArgs, 'convertData'>
   >;
-  createActor?: Resolver<
-    ResolversTypes['Actor'],
+  convertVirtualContributorToUseKnowledgeBase?: Resolver<
+    ResolversTypes['VirtualContributor'],
     ParentType,
     ContextType,
-    RequireFields<MutationCreateActorArgs, 'actorData'>
-  >;
-  createActorGroup?: Resolver<
-    ResolversTypes['ActorGroup'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationCreateActorGroupArgs, 'actorGroupData'>
-  >;
-  createCallout?: Resolver<
-    ResolversTypes['Callout'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationCreateCalloutArgs, 'calloutData'>
+    RequireFields<
+      MutationConvertVirtualContributorToUseKnowledgeBaseArgs,
+      'conversionData'
+    >
   >;
   createCalloutOnCalloutsSet?: Resolver<
     ResolversTypes['Callout'],
@@ -12160,17 +12155,11 @@ export type MutationResolvers<
       'virtualContributorData'
     >
   >;
-  deleteActor?: Resolver<
-    ResolversTypes['Actor'],
+  createWingbackAccount?: Resolver<
+    ResolversTypes['String'],
     ParentType,
     ContextType,
-    RequireFields<MutationDeleteActorArgs, 'deleteData'>
-  >;
-  deleteActorGroup?: Resolver<
-    ResolversTypes['ActorGroup'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationDeleteActorGroupArgs, 'deleteData'>
+    RequireFields<MutationCreateWingbackAccountArgs, 'accountID'>
   >;
   deleteCalendarEvent?: Resolver<
     ResolversTypes['CalendarEvent'],
@@ -12331,13 +12320,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationGrantCredentialToUserArgs, 'grantCredentialData'>
   >;
-  ingest?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  inviteContributorsForRoleSetMembership?: Resolver<
+  inviteContributorsEntryRoleOnRoleSet?: Resolver<
     Array<ResolversTypes['Invitation']>,
     ParentType,
     ContextType,
     RequireFields<
-      MutationInviteContributorsForRoleSetMembershipArgs,
+      MutationInviteContributorsEntryRoleOnRoleSetArgs,
       'invitationData'
     >
   >;
@@ -12346,12 +12334,6 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationInviteUserToPlatformAndRoleSetArgs, 'invitationData'>
-  >;
-  inviteUserToPlatformWithRole?: Resolver<
-    ResolversTypes['PlatformInvitation'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationInviteUserToPlatformWithRoleArgs, 'invitationData'>
   >;
   joinRoleSet?: Resolver<
     ResolversTypes['RoleSet'],
@@ -12406,17 +12388,11 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationRemoveMessageOnRoomArgs, 'messageData'>
   >;
-  removeOrganizationRoleFromUser?: Resolver<
-    ResolversTypes['User'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationRemoveOrganizationRoleFromUserArgs, 'membershipData'>
-  >;
   removePlatformRoleFromUser?: Resolver<
     ResolversTypes['User'],
     ParentType,
     ContextType,
-    RequireFields<MutationRemovePlatformRoleFromUserArgs, 'membershipData'>
+    RequireFields<MutationRemovePlatformRoleFromUserArgs, 'roleData'>
   >;
   removeReactionToMessageInRoom?: Resolver<
     ResolversTypes['Boolean'],
@@ -12515,6 +12491,12 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationSendMessageToUserArgs, 'messageData'>
   >;
+  transferCallout?: Resolver<
+    ResolversTypes['Callout'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationTransferCalloutArgs, 'transferData'>
+  >;
   transferInnovationHubToAccount?: Resolver<
     ResolversTypes['InnovationHub'],
     ParentType,
@@ -12541,12 +12523,6 @@ export type MutationResolvers<
       MutationTransferVirtualContributorToAccountArgs,
       'transferData'
     >
-  >;
-  updateActor?: Resolver<
-    ResolversTypes['Actor'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationUpdateActorArgs, 'actorData'>
   >;
   updateAiPersona?: Resolver<
     ResolversTypes['AiPersona'],
@@ -12632,12 +12608,6 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationUpdateDocumentArgs, 'documentData'>
   >;
-  updateEcosystemModel?: Resolver<
-    ResolversTypes['EcosystemModel'],
-    ParentType,
-    ContextType,
-    RequireFields<MutationUpdateEcosystemModelArgs, 'ecosystemModelData'>
-  >;
   updateInnovationFlow?: Resolver<
     ResolversTypes['InnovationFlow'],
     ParentType,
@@ -12712,6 +12682,12 @@ export type MutationResolvers<
     ParentType,
     ContextType,
     RequireFields<MutationUpdateOrganizationSettingsArgs, 'settingsData'>
+  >;
+  updatePlatformSettings?: Resolver<
+    ResolversTypes['PlatformSettings'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdatePlatformSettingsArgs, 'settingsData'>
   >;
   updatePost?: Resolver<
     ResolversTypes['Post'],
@@ -12812,6 +12788,12 @@ export type MutationResolvers<
       'virtualContributorData'
     >
   >;
+  updateVirtualContributorSettings?: Resolver<
+    ResolversTypes['VirtualContributor'],
+    ParentType,
+    ContextType,
+    RequireFields<MutationUpdateVirtualContributorSettingsArgs, 'settingsData'>
+  >;
   updateVisual?: Resolver<
     ResolversTypes['Visual'],
     ParentType,
@@ -12893,17 +12875,7 @@ export type OrganizationResolvers<
   ParentType extends ResolversParentTypes['Organization'] = ResolversParentTypes['Organization']
 > = {
   account?: Resolver<Maybe<ResolversTypes['Account']>, ParentType, ContextType>;
-  admins?: Resolver<
-    Maybe<Array<ResolversTypes['User']>>,
-    ParentType,
-    ContextType
-  >;
   agent?: Resolver<ResolversTypes['Agent'], ParentType, ContextType>;
-  associates?: Resolver<
-    Maybe<Array<ResolversTypes['User']>>,
-    ParentType,
-    ContextType
-  >;
   authorization?: Resolver<
     Maybe<ResolversTypes['Authorization']>,
     ParentType,
@@ -12942,18 +12914,9 @@ export type OrganizationResolvers<
     ParentType,
     ContextType
   >;
-  myRoles?: Resolver<
-    Maybe<Array<ResolversTypes['OrganizationRole']>>,
-    ParentType,
-    ContextType
-  >;
   nameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
-  owners?: Resolver<
-    Maybe<Array<ResolversTypes['User']>>,
-    ParentType,
-    ContextType
-  >;
   profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
+  roleSet?: Resolver<ResolversTypes['RoleSet'], ParentType, ContextType>;
   settings?: Resolver<
     ResolversTypes['OrganizationSettings'],
     ParentType,
@@ -13055,6 +13018,19 @@ export type OrganizationVerificationResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type OrganizationsInRolesResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['OrganizationsInRolesResponse'] = ResolversParentTypes['OrganizationsInRolesResponse']
+> = {
+  organizations?: Resolver<
+    Array<ResolversTypes['Organization']>,
+    ParentType,
+    ContextType
+  >;
+  role?: Resolver<ResolversTypes['RoleName'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type OryConfigResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['OryConfig'] = ResolversParentTypes['OryConfig']
@@ -13134,6 +13110,11 @@ export type PlatformResolvers<
     ParentType,
     ContextType
   >;
+  chatGuidanceVirtualContributor?: Resolver<
+    ResolversTypes['VirtualContributor'],
+    ParentType,
+    ContextType
+  >;
   configuration?: Resolver<ResolversTypes['Config'], ParentType, ContextType>;
   createdDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
@@ -13160,13 +13141,9 @@ export type PlatformResolvers<
     ContextType
   >;
   metadata?: Resolver<ResolversTypes['Metadata'], ParentType, ContextType>;
-  myRoles?: Resolver<
-    Array<ResolversTypes['PlatformRole']>,
-    ParentType,
-    ContextType
-  >;
-  platformInvitations?: Resolver<
-    Array<ResolversTypes['PlatformInvitation']>,
+  roleSet?: Resolver<ResolversTypes['RoleSet'], ParentType, ContextType>;
+  settings?: Resolver<
+    ResolversTypes['PlatformSettings'],
     ParentType,
     ContextType
   >;
@@ -13201,6 +13178,18 @@ export type PlatformFeatureFlagResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type PlatformIntegrationSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['PlatformIntegrationSettings'] = ResolversParentTypes['PlatformIntegrationSettings']
+> = {
+  iframeAllowedUrls?: Resolver<
+    Array<ResolversTypes['String']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type PlatformInvitationResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['PlatformInvitation'] = ResolversParentTypes['PlatformInvitation']
@@ -13225,13 +13214,13 @@ export type PlatformInvitationResolvers<
   id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   lastName?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   platformRole?: Resolver<
-    Maybe<ResolversTypes['PlatformRole']>,
+    Maybe<ResolversTypes['RoleName']>,
     ParentType,
     ContextType
   >;
   profileCreated?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
   roleSetExtraRole?: Resolver<
-    Maybe<ResolversTypes['CommunityRoleType']>,
+    Maybe<ResolversTypes['RoleName']>,
     ParentType,
     ContextType
   >;
@@ -13286,6 +13275,18 @@ export type PlatformLocationsResolvers<
   switchplan?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   terms?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   tips?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type PlatformSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['PlatformSettings'] = ResolversParentTypes['PlatformSettings']
+> = {
+  integration?: Resolver<
+    ResolversTypes['PlatformIntegrationSettings'],
+    ParentType,
+    ContextType
+  >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -13450,12 +13451,6 @@ export type QueryResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Query'] = ResolversParentTypes['Query']
 > = {
-  account?: Resolver<
-    ResolversTypes['Account'],
-    ParentType,
-    ContextType,
-    RequireFields<QueryAccountArgs, 'ID'>
-  >;
   accounts?: Resolver<
     Array<ResolversTypes['Account']>,
     ParentType,
@@ -13521,8 +13516,7 @@ export type QueryResolvers<
   notifications?: Resolver<
     Array<ResolversTypes['InAppNotification']>,
     ParentType,
-    ContextType,
-    RequireFields<QueryNotificationsArgs, 'receiverID'>
+    ContextType
   >;
   organization?: Resolver<
     ResolversTypes['Organization'],
@@ -13567,12 +13561,6 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QuerySearchArgs, 'searchData'>
   >;
-  space?: Resolver<
-    ResolversTypes['Space'],
-    ParentType,
-    ContextType,
-    RequireFields<QuerySpaceArgs, 'ID'>
-  >;
   spaces?: Resolver<
     Array<ResolversTypes['Space']>,
     ParentType,
@@ -13596,6 +13584,12 @@ export type QueryResolvers<
     ParentType,
     ContextType,
     Partial<QueryTasksArgs>
+  >;
+  urlResolver?: Resolver<
+    ResolversTypes['UrlResolverQueryResults'],
+    ParentType,
+    ContextType,
+    RequireFields<QueryUrlResolverArgs, 'url'>
   >;
   user?: Resolver<
     ResolversTypes['User'],
@@ -13712,6 +13706,7 @@ export type RelayPaginatedSpaceResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['RelayPaginatedSpace'] = ResolversParentTypes['RelayPaginatedSpace']
 > = {
+  about?: Resolver<ResolversTypes['SpaceAbout'], ParentType, ContextType>;
   account?: Resolver<ResolversTypes['Account'], ParentType, ContextType>;
   activeSubscription?: Resolver<
     Maybe<ResolversTypes['SpaceSubscription']>,
@@ -13730,7 +13725,6 @@ export type RelayPaginatedSpaceResolvers<
     ContextType
   >;
   community?: Resolver<ResolversTypes['Community'], ParentType, ContextType>;
-  context?: Resolver<ResolversTypes['Context'], ParentType, ContextType>;
   createdDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -13750,7 +13744,6 @@ export type RelayPaginatedSpaceResolvers<
     ContextType
   >;
   nameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
-  profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
   provider?: Resolver<ResolversTypes['Contributor'], ParentType, ContextType>;
   settings?: Resolver<ResolversTypes['SpaceSettings'], ParentType, ContextType>;
   storageAggregator?: Resolver<
@@ -13763,11 +13756,11 @@ export type RelayPaginatedSpaceResolvers<
     ParentType,
     ContextType
   >;
-  subspace?: Resolver<
+  subspaceByNameID?: Resolver<
     ResolversTypes['Space'],
     ParentType,
     ContextType,
-    RequireFields<RelayPaginatedSpaceSubspaceArgs, 'ID'>
+    RequireFields<RelayPaginatedSpaceSubspaceByNameIdArgs, 'NAMEID'>
   >;
   subspaces?: Resolver<
     Array<ResolversTypes['Space']>,
@@ -13844,6 +13837,7 @@ export type RoleResolvers<
     ContextType
   >;
   id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  name?: Resolver<ResolversTypes['RoleName'], ParentType, ContextType>;
   organizationPolicy?: Resolver<
     ResolversTypes['ContributorRolePolicy'],
     ParentType,
@@ -13864,7 +13858,6 @@ export type RoleResolvers<
     ParentType,
     ContextType
   >;
-  type?: Resolver<ResolversTypes['CommunityRoleType'], ParentType, ContextType>;
   updatedDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -13898,28 +13891,24 @@ export type RoleSetResolvers<
     ParentType,
     ContextType
   >;
-  availableUsersForLeadRole?: Resolver<
+  availableUsersForElevatedRole?: Resolver<
     ResolversTypes['PaginatedUsers'],
     ParentType,
     ContextType,
-    Partial<RoleSetAvailableUsersForLeadRoleArgs>
+    RequireFields<RoleSetAvailableUsersForElevatedRoleArgs, 'role'>
   >;
-  availableUsersForMemberRole?: Resolver<
+  availableUsersForEntryRole?: Resolver<
     ResolversTypes['PaginatedUsers'],
     ParentType,
     ContextType,
-    Partial<RoleSetAvailableUsersForMemberRoleArgs>
+    Partial<RoleSetAvailableUsersForEntryRoleArgs>
   >;
   createdDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
     ParentType,
     ContextType
   >;
-  entryRoleType?: Resolver<
-    ResolversTypes['CommunityRoleType'],
-    ParentType,
-    ContextType
-  >;
+  entryRoleName?: Resolver<ResolversTypes['RoleName'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   invitations?: Resolver<
     Array<ResolversTypes['Invitation']>,
@@ -13933,12 +13922,12 @@ export type RoleSetResolvers<
     ContextType
   >;
   myRoles?: Resolver<
-    Array<ResolversTypes['CommunityRoleType']>,
+    Array<ResolversTypes['RoleName']>,
     ParentType,
     ContextType
   >;
   myRolesImplicit?: Resolver<
-    Array<ResolversTypes['CommunityRoleImplicit']>,
+    Array<ResolversTypes['RoleSetRoleImplicit']>,
     ParentType,
     ContextType
   >;
@@ -13947,6 +13936,12 @@ export type RoleSetResolvers<
     ParentType,
     ContextType,
     RequireFields<RoleSetOrganizationsInRoleArgs, 'role'>
+  >;
+  organizationsInRoles?: Resolver<
+    Array<ResolversTypes['OrganizationsInRolesResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<RoleSetOrganizationsInRolesArgs, 'roles'>
   >;
   platformInvitations?: Resolver<
     Array<ResolversTypes['PlatformInvitation']>,
@@ -13962,6 +13957,17 @@ export type RoleSetResolvers<
   roleDefinitions?: Resolver<
     Array<ResolversTypes['Role']>,
     ParentType,
+    ContextType,
+    Partial<RoleSetRoleDefinitionsArgs>
+  >;
+  roleNames?: Resolver<
+    Array<ResolversTypes['RoleName']>,
+    ParentType,
+    ContextType
+  >;
+  type?: Resolver<
+    Maybe<ResolversTypes['RoleSetType']>,
+    ParentType,
     ContextType
   >;
   updatedDate?: Resolver<
@@ -13975,11 +13981,23 @@ export type RoleSetResolvers<
     ContextType,
     RequireFields<RoleSetUsersInRoleArgs, 'role'>
   >;
+  usersInRoles?: Resolver<
+    Array<ResolversTypes['UsersInRolesResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<RoleSetUsersInRolesArgs, 'roles'>
+  >;
   virtualContributorsInRole?: Resolver<
     Array<ResolversTypes['VirtualContributor']>,
     ParentType,
     ContextType,
     RequireFields<RoleSetVirtualContributorsInRoleArgs, 'role'>
+  >;
+  virtualContributorsInRoles?: Resolver<
+    Array<ResolversTypes['VirtualContributorsInRolesResponse']>,
+    ParentType,
+    ContextType,
+    RequireFields<RoleSetVirtualContributorsInRolesArgs, 'roles'>
   >;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
@@ -14253,6 +14271,7 @@ export type SpaceResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Space'] = ResolversParentTypes['Space']
 > = {
+  about?: Resolver<ResolversTypes['SpaceAbout'], ParentType, ContextType>;
   account?: Resolver<ResolversTypes['Account'], ParentType, ContextType>;
   activeSubscription?: Resolver<
     Maybe<ResolversTypes['SpaceSubscription']>,
@@ -14271,7 +14290,6 @@ export type SpaceResolvers<
     ContextType
   >;
   community?: Resolver<ResolversTypes['Community'], ParentType, ContextType>;
-  context?: Resolver<ResolversTypes['Context'], ParentType, ContextType>;
   createdDate?: Resolver<
     Maybe<ResolversTypes['DateTime']>,
     ParentType,
@@ -14291,7 +14309,6 @@ export type SpaceResolvers<
     ContextType
   >;
   nameID?: Resolver<ResolversTypes['NameID'], ParentType, ContextType>;
-  profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
   provider?: Resolver<ResolversTypes['Contributor'], ParentType, ContextType>;
   settings?: Resolver<ResolversTypes['SpaceSettings'], ParentType, ContextType>;
   storageAggregator?: Resolver<
@@ -14304,11 +14321,11 @@ export type SpaceResolvers<
     ParentType,
     ContextType
   >;
-  subspace?: Resolver<
+  subspaceByNameID?: Resolver<
     ResolversTypes['Space'],
     ParentType,
     ContextType,
-    RequireFields<SpaceSubspaceArgs, 'ID'>
+    RequireFields<SpaceSubspaceByNameIdArgs, 'NAMEID'>
   >;
   subspaces?: Resolver<
     Array<ResolversTypes['Space']>,
@@ -14335,19 +14352,44 @@ export type SpaceResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type SpaceAboutResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['SpaceAbout'] = ResolversParentTypes['SpaceAbout']
+> = {
+  authorization?: Resolver<
+    Maybe<ResolversTypes['Authorization']>,
+    ParentType,
+    ContextType
+  >;
+  createdDate?: Resolver<
+    Maybe<ResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
+  updatedDate?: Resolver<
+    Maybe<ResolversTypes['DateTime']>,
+    ParentType,
+    ContextType
+  >;
+  who?: Resolver<Maybe<ResolversTypes['Markdown']>, ParentType, ContextType>;
+  why?: Resolver<Maybe<ResolversTypes['Markdown']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type SpacePendingMembershipInfoResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['SpacePendingMembershipInfo'] = ResolversParentTypes['SpacePendingMembershipInfo']
 > = {
+  about?: Resolver<ResolversTypes['SpaceAbout'], ParentType, ContextType>;
   communityGuidelines?: Resolver<
     ResolversTypes['CommunityGuidelines'],
     ParentType,
     ContextType
   >;
-  context?: Resolver<ResolversTypes['Context'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
   level?: Resolver<ResolversTypes['SpaceLevel'], ParentType, ContextType>;
-  profile?: Resolver<ResolversTypes['Profile'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -14978,20 +15020,161 @@ export interface UuidScalarConfig
   name: 'UUID';
 }
 
-export interface Uuid_NameidScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['UUID_NAMEID'], any> {
-  name: 'UUID_NAMEID';
-}
-
-export interface Uuid_Nameid_EmailScalarConfig
-  extends GraphQLScalarTypeConfig<ResolversTypes['UUID_NAMEID_EMAIL'], any> {
-  name: 'UUID_NAMEID_EMAIL';
-}
-
 export interface UploadScalarConfig
   extends GraphQLScalarTypeConfig<ResolversTypes['Upload'], any> {
   name: 'Upload';
 }
+
+export type UrlResolverQueryResultCalendarResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResultCalendar'] = ResolversParentTypes['UrlResolverQueryResultCalendar']
+> = {
+  calendarEventId?: Resolver<
+    Maybe<ResolversTypes['UUID']>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UrlResolverQueryResultCalloutsSetResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResultCalloutsSet'] = ResolversParentTypes['UrlResolverQueryResultCalloutsSet']
+> = {
+  calloutId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  contributionId?: Resolver<
+    Maybe<ResolversTypes['UUID']>,
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  postId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  type?: Resolver<ResolversTypes['UrlType'], ParentType, ContextType>;
+  whiteboardId?: Resolver<
+    Maybe<ResolversTypes['UUID']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UrlResolverQueryResultCollaborationResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResultCollaboration'] = ResolversParentTypes['UrlResolverQueryResultCollaboration']
+> = {
+  calloutsSet?: Resolver<
+    ResolversTypes['UrlResolverQueryResultCalloutsSet'],
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UrlResolverQueryResultInnovationPackResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResultInnovationPack'] = ResolversParentTypes['UrlResolverQueryResultInnovationPack']
+> = {
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  templatesSet?: Resolver<
+    ResolversTypes['UrlResolverQueryResultTemplatesSet'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UrlResolverQueryResultSpaceResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResultSpace'] = ResolversParentTypes['UrlResolverQueryResultSpace']
+> = {
+  calendar?: Resolver<
+    Maybe<ResolversTypes['UrlResolverQueryResultCalendar']>,
+    ParentType,
+    ContextType
+  >;
+  collaboration?: Resolver<
+    ResolversTypes['UrlResolverQueryResultCollaboration'],
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  level?: Resolver<ResolversTypes['SpaceLevel'], ParentType, ContextType>;
+  levelZeroSpaceID?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  parentSpaces?: Resolver<
+    Array<ResolversTypes['UUID']>,
+    ParentType,
+    ContextType
+  >;
+  templatesSet?: Resolver<
+    Maybe<ResolversTypes['UrlResolverQueryResultTemplatesSet']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UrlResolverQueryResultTemplatesSetResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResultTemplatesSet'] = ResolversParentTypes['UrlResolverQueryResultTemplatesSet']
+> = {
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  templateId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UrlResolverQueryResultVirtualContributorResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResultVirtualContributor'] = ResolversParentTypes['UrlResolverQueryResultVirtualContributor']
+> = {
+  calloutsSet?: Resolver<
+    ResolversTypes['UrlResolverQueryResultCalloutsSet'],
+    ParentType,
+    ContextType
+  >;
+  id?: Resolver<ResolversTypes['UUID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type UrlResolverQueryResultsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UrlResolverQueryResults'] = ResolversParentTypes['UrlResolverQueryResults']
+> = {
+  discussionId?: Resolver<
+    Maybe<ResolversTypes['UUID']>,
+    ParentType,
+    ContextType
+  >;
+  innovationHubId?: Resolver<
+    Maybe<ResolversTypes['UUID']>,
+    ParentType,
+    ContextType
+  >;
+  innovationPack?: Resolver<
+    Maybe<ResolversTypes['UrlResolverQueryResultInnovationPack']>,
+    ParentType,
+    ContextType
+  >;
+  organizationId?: Resolver<
+    Maybe<ResolversTypes['UUID']>,
+    ParentType,
+    ContextType
+  >;
+  space?: Resolver<
+    Maybe<ResolversTypes['UrlResolverQueryResultSpace']>,
+    ParentType,
+    ContextType
+  >;
+  type?: Resolver<ResolversTypes['UrlType'], ParentType, ContextType>;
+  userId?: Resolver<Maybe<ResolversTypes['UUID']>, ParentType, ContextType>;
+  virtualContributor?: Resolver<
+    Maybe<ResolversTypes['UrlResolverQueryResultVirtualContributor']>,
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
 
 export type UserResolvers<
   ContextType = any,
@@ -15149,6 +15332,15 @@ export type UserSettingsPrivacyResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type UsersInRolesResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['UsersInRolesResponse'] = ResolversParentTypes['UsersInRolesResponse']
+> = {
+  role?: Resolver<ResolversTypes['RoleName'], ParentType, ContextType>;
+  users?: Resolver<Array<ResolversTypes['User']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type VcInteractionResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['VcInteraction'] = ResolversParentTypes['VcInteraction']
@@ -15237,6 +15429,11 @@ export type VirtualContributorResolvers<
     ParentType,
     ContextType
   >;
+  settings?: Resolver<
+    ResolversTypes['VirtualContributorSettings'],
+    ParentType,
+    ContextType
+  >;
   status?: Resolver<
     ResolversTypes['VirtualContributorStatus'],
     ParentType,
@@ -15250,12 +15447,49 @@ export type VirtualContributorResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type VirtualContributorSettingsResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['VirtualContributorSettings'] = ResolversParentTypes['VirtualContributorSettings']
+> = {
+  privacy?: Resolver<
+    ResolversTypes['VirtualContributorSettingsPrivacy'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type VirtualContributorSettingsPrivacyResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['VirtualContributorSettingsPrivacy'] = ResolversParentTypes['VirtualContributorSettingsPrivacy']
+> = {
+  knowledgeBaseContentVisible?: Resolver<
+    ResolversTypes['Boolean'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type VirtualContributorUpdatedSubscriptionResultResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['VirtualContributorUpdatedSubscriptionResult'] = ResolversParentTypes['VirtualContributorUpdatedSubscriptionResult']
 > = {
   virtualContributor?: Resolver<
     ResolversTypes['VirtualContributor'],
+    ParentType,
+    ContextType
+  >;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type VirtualContributorsInRolesResponseResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['VirtualContributorsInRolesResponse'] = ResolversParentTypes['VirtualContributorsInRolesResponse']
+> = {
+  role?: Resolver<ResolversTypes['RoleName'], ParentType, ContextType>;
+  virtualContributors?: Resolver<
+    Array<ResolversTypes['VirtualContributor']>,
     ParentType,
     ContextType
   >;
@@ -15376,8 +15610,6 @@ export type Resolvers<ContextType = any> = {
   ActivityLogEntryMemberJoined?: ActivityLogEntryMemberJoinedResolvers<ContextType>;
   ActivityLogEntryOpportunityCreated?: ActivityLogEntryOpportunityCreatedResolvers<ContextType>;
   ActivityLogEntryUpdateSent?: ActivityLogEntryUpdateSentResolvers<ContextType>;
-  Actor?: ActorResolvers<ContextType>;
-  ActorGroup?: ActorGroupResolvers<ContextType>;
   Agent?: AgentResolvers<ContextType>;
   AgentBeginVerifiedCredentialOfferOutput?: AgentBeginVerifiedCredentialOfferOutputResolvers<ContextType>;
   AgentBeginVerifiedCredentialRequestOutput?: AgentBeginVerifiedCredentialRequestOutputResolvers<ContextType>;
@@ -15417,7 +15649,6 @@ export type Resolvers<ContextType = any> = {
   CommunityInvitationResult?: CommunityInvitationResultResolvers<ContextType>;
   CommunityMembershipResult?: CommunityMembershipResultResolvers<ContextType>;
   Config?: ConfigResolvers<ContextType>;
-  Context?: ContextResolvers<ContextType>;
   Contributor?: ContributorResolvers<ContextType>;
   ContributorRolePolicy?: ContributorRolePolicyResolvers<ContextType>;
   ContributorRoles?: ContributorRolesResolvers<ContextType>;
@@ -15444,7 +15675,6 @@ export type Resolvers<ContextType = any> = {
   DirectRoom?: DirectRoomResolvers<ContextType>;
   Discussion?: DiscussionResolvers<ContextType>;
   Document?: DocumentResolvers<ContextType>;
-  EcosystemModel?: EcosystemModelResolvers<ContextType>;
   Emoji?: GraphQLScalarType;
   FileStorageConfig?: FileStorageConfigResolvers<ContextType>;
   Form?: FormResolvers<ContextType>;
@@ -15458,6 +15688,7 @@ export type Resolvers<ContextType = any> = {
   InAppNotificationCommunityNewMember?: InAppNotificationCommunityNewMemberResolvers<ContextType>;
   InAppNotificationUserMentioned?: InAppNotificationUserMentionedResolvers<ContextType>;
   InnovationFlow?: InnovationFlowResolvers<ContextType>;
+  InnovationFlowSettings?: InnovationFlowSettingsResolvers<ContextType>;
   InnovationFlowState?: InnovationFlowStateResolvers<ContextType>;
   InnovationHub?: InnovationHubResolvers<ContextType>;
   InnovationPack?: InnovationPackResolvers<ContextType>;
@@ -15497,6 +15728,7 @@ export type Resolvers<ContextType = any> = {
   OrganizationSettingsMembership?: OrganizationSettingsMembershipResolvers<ContextType>;
   OrganizationSettingsPrivacy?: OrganizationSettingsPrivacyResolvers<ContextType>;
   OrganizationVerification?: OrganizationVerificationResolvers<ContextType>;
+  OrganizationsInRolesResponse?: OrganizationsInRolesResponseResolvers<ContextType>;
   OryConfig?: OryConfigResolvers<ContextType>;
   PageInfo?: PageInfoResolvers<ContextType>;
   PaginatedOrganization?: PaginatedOrganizationResolvers<ContextType>;
@@ -15504,8 +15736,10 @@ export type Resolvers<ContextType = any> = {
   PaginatedUsers?: PaginatedUsersResolvers<ContextType>;
   Platform?: PlatformResolvers<ContextType>;
   PlatformFeatureFlag?: PlatformFeatureFlagResolvers<ContextType>;
+  PlatformIntegrationSettings?: PlatformIntegrationSettingsResolvers<ContextType>;
   PlatformInvitation?: PlatformInvitationResolvers<ContextType>;
   PlatformLocations?: PlatformLocationsResolvers<ContextType>;
+  PlatformSettings?: PlatformSettingsResolvers<ContextType>;
   Post?: PostResolvers<ContextType>;
   Preference?: PreferenceResolvers<ContextType>;
   PreferenceDefinition?: PreferenceDefinitionResolvers<ContextType>;
@@ -15538,6 +15772,7 @@ export type Resolvers<ContextType = any> = {
   Sentry?: SentryResolvers<ContextType>;
   ServiceMetadata?: ServiceMetadataResolvers<ContextType>;
   Space?: SpaceResolvers<ContextType>;
+  SpaceAbout?: SpaceAboutResolvers<ContextType>;
   SpacePendingMembershipInfo?: SpacePendingMembershipInfoResolvers<ContextType>;
   SpaceSettings?: SpaceSettingsResolvers<ContextType>;
   SpaceSettingsCollaboration?: SpaceSettingsCollaborationResolvers<ContextType>;
@@ -15561,20 +15796,30 @@ export type Resolvers<ContextType = any> = {
   TemplatesSet?: TemplatesSetResolvers<ContextType>;
   Timeline?: TimelineResolvers<ContextType>;
   UUID?: GraphQLScalarType;
-  UUID_NAMEID?: GraphQLScalarType;
-  UUID_NAMEID_EMAIL?: GraphQLScalarType;
   Upload?: GraphQLScalarType;
+  UrlResolverQueryResultCalendar?: UrlResolverQueryResultCalendarResolvers<ContextType>;
+  UrlResolverQueryResultCalloutsSet?: UrlResolverQueryResultCalloutsSetResolvers<ContextType>;
+  UrlResolverQueryResultCollaboration?: UrlResolverQueryResultCollaborationResolvers<ContextType>;
+  UrlResolverQueryResultInnovationPack?: UrlResolverQueryResultInnovationPackResolvers<ContextType>;
+  UrlResolverQueryResultSpace?: UrlResolverQueryResultSpaceResolvers<ContextType>;
+  UrlResolverQueryResultTemplatesSet?: UrlResolverQueryResultTemplatesSetResolvers<ContextType>;
+  UrlResolverQueryResultVirtualContributor?: UrlResolverQueryResultVirtualContributorResolvers<ContextType>;
+  UrlResolverQueryResults?: UrlResolverQueryResultsResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
   UserAuthenticationResult?: UserAuthenticationResultResolvers<ContextType>;
   UserGroup?: UserGroupResolvers<ContextType>;
   UserSettings?: UserSettingsResolvers<ContextType>;
   UserSettingsCommunication?: UserSettingsCommunicationResolvers<ContextType>;
   UserSettingsPrivacy?: UserSettingsPrivacyResolvers<ContextType>;
+  UsersInRolesResponse?: UsersInRolesResponseResolvers<ContextType>;
   VcInteraction?: VcInteractionResolvers<ContextType>;
   VerifiedCredential?: VerifiedCredentialResolvers<ContextType>;
   VerifiedCredentialClaim?: VerifiedCredentialClaimResolvers<ContextType>;
   VirtualContributor?: VirtualContributorResolvers<ContextType>;
+  VirtualContributorSettings?: VirtualContributorSettingsResolvers<ContextType>;
+  VirtualContributorSettingsPrivacy?: VirtualContributorSettingsPrivacyResolvers<ContextType>;
   VirtualContributorUpdatedSubscriptionResult?: VirtualContributorUpdatedSubscriptionResultResolvers<ContextType>;
+  VirtualContributorsInRolesResponse?: VirtualContributorsInRolesResponseResolvers<ContextType>;
   Visual?: VisualResolvers<ContextType>;
   VisualConstraints?: VisualConstraintsResolvers<ContextType>;
   Whiteboard?: WhiteboardResolvers<ContextType>;
@@ -15732,43 +15977,60 @@ export type ProfileNoTagsetFieldsFragment = {
 export type SpaceDetailsFragment = {
   id: string;
   nameID: string;
-  profile: {
-    displayName: string;
-    visuals: Array<{ name: string; id: string }>;
-    tagset?: { tags: Array<string>; id: string; name: string } | undefined;
+  about: {
+    id: string;
+    profile: {
+      id: string;
+      description?: any | undefined;
+      displayName: string;
+      tagline?: string | undefined;
+      url: string;
+      type?: ProfileType | undefined;
+      location?:
+        | {
+            city?: string | undefined;
+            country?: string | undefined;
+            postalCode?: string | undefined;
+          }
+        | undefined;
+      tagset?: { tags: Array<string> } | undefined;
+      references?:
+        | Array<{ description?: string | undefined; name: string; uri: string }>
+        | undefined;
+      visuals: Array<{ uri: string; name: string }>;
+    };
   };
   community: { id: string };
-  context: { id: string };
 };
 
 export type SpaceIngestFragment = {
   id: string;
   nameID: string;
   type: SpaceType;
-  profile: {
+  about: {
     id: string;
-    description?: any | undefined;
-    displayName: string;
-    tagline?: string | undefined;
-    url: string;
-    type?: ProfileType | undefined;
-    location?:
-      | {
-          city?: string | undefined;
-          country?: string | undefined;
-          postalCode?: string | undefined;
-        }
-      | undefined;
-    tagset?: { tags: Array<string> } | undefined;
-    references?:
-      | Array<{ description?: string | undefined; name: string; uri: string }>
-      | undefined;
-    visuals: Array<{ uri: string; name: string }>;
-  };
-  context: {
-    vision?: any | undefined;
-    impact?: any | undefined;
     who?: any | undefined;
+    why?: any | undefined;
+    profile: {
+      id: string;
+      description?: any | undefined;
+      displayName: string;
+      tagline?: string | undefined;
+      url: string;
+      type?: ProfileType | undefined;
+      location?:
+        | {
+            city?: string | undefined;
+            country?: string | undefined;
+            postalCode?: string | undefined;
+          }
+        | undefined;
+      tagset?: { tags: Array<string> } | undefined;
+      references?:
+        | Array<{ description?: string | undefined; name: string; uri: string }>
+        | undefined;
+      visuals: Array<{ uri: string; name: string }>;
+    };
   };
   collaboration: {
     calloutsSet: {
@@ -16225,34 +16487,34 @@ export type SpaceIngestQuery = {
               id: string;
               nameID: string;
               type: SpaceType;
-              profile: {
+              about: {
                 id: string;
-                description?: any | undefined;
-                displayName: string;
-                tagline?: string | undefined;
-                url: string;
-                type?: ProfileType | undefined;
-                location?:
-                  | {
-                      city?: string | undefined;
-                      country?: string | undefined;
-                      postalCode?: string | undefined;
-                    }
-                  | undefined;
-                tagset?: { tags: Array<string> } | undefined;
-                references?:
-                  | Array<{
-                      description?: string | undefined;
-                      name: string;
-                      uri: string;
-                    }>
-                  | undefined;
-                visuals: Array<{ uri: string; name: string }>;
-              };
-              context: {
-                vision?: any | undefined;
-                impact?: any | undefined;
                 who?: any | undefined;
+                why?: any | undefined;
+                profile: {
+                  id: string;
+                  description?: any | undefined;
+                  displayName: string;
+                  tagline?: string | undefined;
+                  url: string;
+                  type?: ProfileType | undefined;
+                  location?:
+                    | {
+                        city?: string | undefined;
+                        country?: string | undefined;
+                        postalCode?: string | undefined;
+                      }
+                    | undefined;
+                  tagset?: { tags: Array<string> } | undefined;
+                  references?:
+                    | Array<{
+                        description?: string | undefined;
+                        name: string;
+                        uri: string;
+                      }>
+                    | undefined;
+                  visuals: Array<{ uri: string; name: string }>;
+                };
               };
               collaboration: {
                 calloutsSet: {
@@ -16364,34 +16626,34 @@ export type SpaceIngestQuery = {
                 };
               };
             }>;
-            profile: {
+            about: {
               id: string;
-              description?: any | undefined;
-              displayName: string;
-              tagline?: string | undefined;
-              url: string;
-              type?: ProfileType | undefined;
-              location?:
-                | {
-                    city?: string | undefined;
-                    country?: string | undefined;
-                    postalCode?: string | undefined;
-                  }
-                | undefined;
-              tagset?: { tags: Array<string> } | undefined;
-              references?:
-                | Array<{
-                    description?: string | undefined;
-                    name: string;
-                    uri: string;
-                  }>
-                | undefined;
-              visuals: Array<{ uri: string; name: string }>;
-            };
-            context: {
-              vision?: any | undefined;
-              impact?: any | undefined;
               who?: any | undefined;
+              why?: any | undefined;
+              profile: {
+                id: string;
+                description?: any | undefined;
+                displayName: string;
+                tagline?: string | undefined;
+                url: string;
+                type?: ProfileType | undefined;
+                location?:
+                  | {
+                      city?: string | undefined;
+                      country?: string | undefined;
+                      postalCode?: string | undefined;
+                    }
+                  | undefined;
+                tagset?: { tags: Array<string> } | undefined;
+                references?:
+                  | Array<{
+                      description?: string | undefined;
+                      name: string;
+                      uri: string;
+                    }>
+                  | undefined;
+                visuals: Array<{ uri: string; name: string }>;
+              };
             };
             collaboration: {
               calloutsSet: {
@@ -16499,34 +16761,34 @@ export type SpaceIngestQuery = {
               };
             };
           }>;
-          profile: {
+          about: {
             id: string;
-            description?: any | undefined;
-            displayName: string;
-            tagline?: string | undefined;
-            url: string;
-            type?: ProfileType | undefined;
-            location?:
-              | {
-                  city?: string | undefined;
-                  country?: string | undefined;
-                  postalCode?: string | undefined;
-                }
-              | undefined;
-            tagset?: { tags: Array<string> } | undefined;
-            references?:
-              | Array<{
-                  description?: string | undefined;
-                  name: string;
-                  uri: string;
-                }>
-              | undefined;
-            visuals: Array<{ uri: string; name: string }>;
-          };
-          context: {
-            vision?: any | undefined;
-            impact?: any | undefined;
             who?: any | undefined;
+            why?: any | undefined;
+            profile: {
+              id: string;
+              description?: any | undefined;
+              displayName: string;
+              tagline?: string | undefined;
+              url: string;
+              type?: ProfileType | undefined;
+              location?:
+                | {
+                    city?: string | undefined;
+                    country?: string | undefined;
+                    postalCode?: string | undefined;
+                  }
+                | undefined;
+              tagset?: { tags: Array<string> } | undefined;
+              references?:
+                | Array<{
+                    description?: string | undefined;
+                    name: string;
+                    uri: string;
+                  }>
+                | undefined;
+              visuals: Array<{ uri: string; name: string }>;
+            };
           };
           collaboration: {
             calloutsSet: {
@@ -16638,30 +16900,6 @@ export type SpaceIngestQuery = {
   };
 };
 
-export const SpaceDetailsFragmentDoc = gql`
-  fragment SpaceDetails on Space {
-    id
-    nameID
-    profile {
-      displayName
-      visuals {
-        name
-        id
-      }
-      tagset {
-        tags
-        id
-        name
-      }
-    }
-    community {
-      id
-    }
-    context {
-      id
-    }
-  }
-`;
 export const ProfileFieldsFragmentDoc = gql`
   fragment ProfileFields on Profile {
     id
@@ -16688,6 +16926,22 @@ export const ProfileFieldsFragmentDoc = gql`
       name
     }
   }
+`;
+export const SpaceDetailsFragmentDoc = gql`
+  fragment SpaceDetails on Space {
+    id
+    nameID
+    about {
+      id
+      profile {
+        ...ProfileFields
+      }
+    }
+    community {
+      id
+    }
+  }
+  ${ProfileFieldsFragmentDoc}
 `;
 export const ProfileNoTagsetFieldsFragmentDoc = gql`
   fragment ProfileNoTagsetFields on Profile {
@@ -16766,13 +17020,13 @@ export const SpaceIngestFragmentDoc = gql`
     id
     nameID
     type
-    profile {
-      ...ProfileFields
-    }
-    context {
-      vision
-      impact
+    about {
+      id
+      profile {
+        ...ProfileFields
+      }
       who
+      why
     }
     collaboration {
       calloutsSet {


### PR DESCRIPTION
Fixes: https://github.com/alkem-io/virtual-contributor-ingest-space/issues/71
- update GQL queries to handle space profile movement under space about
- handle both Space and KnowledgeBase structure
- parse HTML in descriptions and get only the text


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced document processing with improved HTML content parsing and robust data fallbacks for consistent content display.
  - Introduced new `about` field in data structures, providing better organization of profile-related information.

- **Refactor**
  - Redesigned data retrieval structures for profile and context, streamlining how content is organized.
  - Updated internal module integrations for cleaner, more reliable performance.

- **Chores**
  - Upgraded the package version to 0.13.0 and introduced a new HTML parsing dependency to support improved processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->